### PR TITLE
ablitity to set correct Content-Type for stream data

### DIFF
--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -154,6 +154,19 @@ public interface Sardine
 	void put(String url, InputStream dataStream, String contentType, boolean expectContinue) throws IOException;
 
 	/**
+	 * Uses <code>PUT</code> to send data to a server with a specific content
+	 * type header. Not repeatable on authentication failure.
+	 *
+	 * @param url			Path to the resource including protocol and hostname
+	 * @param dataStream	 Input source
+	 * @param contentType	MIME type to add to the HTTP request header
+	 * @param expectContinue Enable <code>Expect: continue</code> header for <code>PUT</code> requests.
+	 * @param contentLength data size in bytes to set to Content-Length header
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	void put(String url, InputStream dataStream, String contentType, boolean expectContinue, long contentLength) throws IOException;
+
+	/**
 	 * Uses <code>PUT</code> to send data to a server with specific headers. Not repeatable
 	 * on authentication failure.
 	 *

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -680,7 +680,13 @@ public class SardineImpl implements Sardine
 	public void put(String url, InputStream dataStream, String contentType, boolean expectContinue) throws IOException
 	{
 		// A length of -1 means "go until end of stream"
-		InputStreamEntity entity = new InputStreamEntity(dataStream, -1);
+		put(url, dataStream, contentType, expectContinue, -1);
+	}
+
+	@Override
+	public void put(String url, InputStream dataStream, String contentType, boolean expectContinue, long contentLength) throws IOException
+	{
+		InputStreamEntity entity = new InputStreamEntity(dataStream, contentLength);
 		this.put(url, entity, contentType, expectContinue);
 	}
 


### PR DESCRIPTION
Currently, Content-Length header is not set for PUT requests which accept InputStream as data. Content-Length is set automatically for byte array PUTs, but it's dangerous to use byte arrays for sending big files. So I've added a parameter to InputStream PUT to specify data size, if it is known.
