### PR TITLE
Additional "list" in interface

### DIFF
--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The main interface for Sardine operations.
@@ -65,6 +66,17 @@ public interface Sardine
 	 * @throws IOException I/O error or HTTP response validation failure
 	 */
 	List<DavResource> list(String url, int depth, Map<QName, String> props) throws IOException;
+
+	/**
+	 * Gets a directory listing using WebDAV <code>PROPFIND</code>.
+	 *
+	 * @param url   Path to the resource including protocol and hostname
+	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing)
+	 * @param props Additional properties which should be requested.
+	 * @return List of resources for this URI including the parent resource itself
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	List<DavResource> list(String url, int depth, Set<QName> props) throws IOException;
 
 	/**
 	 * Gets a directory listing using WebDAV <code>PROPFIND</code>.

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -324,12 +324,12 @@ public class SardineImpl implements Sardine
 			body.setAllprop(new Allprop());
 			return list(url, depth, body);
 		} else {
-			return list(url, depth, Collections.<QName, String>emptyMap());
+			return list(url, depth, Collections.<QName>emptySet());
 		}
 	}
 
 	@Override
-	public List<DavResource> list(String url, int depth, Map<QName, String> props) throws IOException
+	public List<DavResource> list(String url, int depth, java.util.Set<QName> props) throws IOException
 	{
 		Propfind body = new Propfind();
                 
@@ -344,15 +344,15 @@ public class SardineImpl implements Sardine
 		prop.setGetetag(objectFactory.createGetetag());
                 
 		List<Element> any = prop.getAny();
-		for (Map.Entry<QName, String> entry : props.entrySet()) {
-			Element element = SardineUtil.createElement(entry.getKey());
+		for (QName entry : props) {
+			Element element = SardineUtil.createElement(entry);
 			any.add(element);
 		}
 
 		body.setProp(prop);
                 
 		return list(url, depth, body);
-        }
+		}
 
 	protected List<DavResource> list(String url, int depth, Propfind body) throws IOException
 	{

--- a/src/test/java/com/github/sardine/ProppatchTest.java
+++ b/src/test/java/com/github/sardine/ProppatchTest.java
@@ -86,7 +86,7 @@ public class ProppatchTest
 				assertTrue(resource.getCustomProps().containsKey("fish"));
 			}
 			{
-				List<DavResource> resources = sardine.list(url, 0, patch);
+				List<DavResource> resources = sardine.list(url, 0, patch.keySet());
 				assertNotNull(resources);
 				assertEquals(1, resources.size());
 				DavResource resource = resources.iterator().next();


### PR DESCRIPTION
Extended interface to allow to explicitly request specific non standard properties when requesting a PROPFIND listing.

This is necessary/can be useful because some WebDAV servers do not return special properties until they are explicitly requested. In these cases allProps=true does not return the desired properties. The suggested change allows to get them anyway.
