### PR TITLE
Additional "list" in interface

### DIFF
--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The main interface for Sardine operations.
@@ -54,6 +55,17 @@ public interface Sardine
 	 * @throws IOException I/O error or HTTP response validation failure
 	 */
 	List<DavResource> list(String url, int depth) throws IOException;
+
+	/**
+	 * Gets a directory listing using WebDAV <code>PROPFIND</code>.
+	 *
+	 * @param url   Path to the resource including protocol and hostname
+	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing)
+	 * @param props Additional properties which should be requested.
+	 * @return List of resources for this URI including the parent resource itself
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	List<DavResource> list(String url, int depth, Set<QName> props) throws IOException;
 
 	/**
 	 * Gets a directory listing using WebDAV <code>PROPFIND</code>.

--- a/src/test/java/com/github/sardine/ProppatchTest.java
+++ b/src/test/java/com/github/sardine/ProppatchTest.java
@@ -86,7 +86,7 @@ public class ProppatchTest
 				assertTrue(resource.getCustomProps().containsKey("fish"));
 			}
 			{
-				List<DavResource> resources = sardine.list(url);
+				List<DavResource> resources = sardine.list(url, 0, patch.keySet());
 				assertNotNull(resources);
 				assertEquals(1, resources.size());
 				DavResource resource = resources.iterator().next();


### PR DESCRIPTION
Extended interface to allow to explicitly request specific non standard properties when requesting a list.
This is necessary because some WebDAV servers do not return special properties until they are explicitly requested.

(replaces #167)
