### PR TITLE
Support for building javadocs on Java 8

### DIFF
--- a/src/main/java/com/github/sardine/DavAce.java
+++ b/src/main/java/com/github/sardine/DavAce.java
@@ -38,19 +38,19 @@ public class DavAce
 	 * A "principal" is a distinct human or computational actor that
 	 * initiates access to network resources.  In this protocol, a
 	 * principal is an HTTP resource that represents such an actor.
-	 * <p/>
+	 * <p></p>
 	 * The DAV:principal element identifies the principal to which this ACE
 	 * applies.
-	 * <p/>
+	 * <p></p>
 	 * <!ELEMENT principal (href | all | authenticated | unauthenticated
 	 * | property | self)>
-	 * <p/>
+	 * <p></p>
 	 * The current user matches DAV:href only if that user is authenticated
 	 * as being (or being a member of) the principal identified by the URL
 	 * contained by that DAV:href.
-	 * <p/>
+	 * <p></p>
 	 * Either a href or one of all,authenticated,unauthenticated,property,self.
-	 * <p/>
+	 * <p></p>
 	 * DAV:property not supported.
 	 */
 	private final DavPrincipal principal;
@@ -71,7 +71,7 @@ public class DavAce
 	 * contained in a DAV:href element.  An inherited ACE cannot be modified
 	 * directly, but instead the ACL on the resource from which it is
 	 * inherited must be modified.
-	 * <p/>
+	 * <p></p>
 	 * Null or a href to the inherited resource.
 	 */
 	private final String inherited;

--- a/src/main/java/com/github/sardine/DavPrincipal.java
+++ b/src/main/java/com/github/sardine/DavPrincipal.java
@@ -15,19 +15,19 @@ public class DavPrincipal
 	 * A "principal" is a distinct human or computational actor that
 	 * initiates access to network resources.  In this protocol, a
 	 * principal is an HTTP resource that represents such an actor.
-	 * <p/>
+	 * <p></p>
 	 * The DAV:principal element identifies the principal to which this ACE
 	 * applies.
-	 * <p/>
-	 * <!ELEMENT principal (href | all | authenticated | unauthenticated
-	 * | property | self)>
-	 * <p/>
+	 * <p></p>
+	 * &lt;!ELEMENT principal (href | all | authenticated | unauthenticated
+	 * | property | self)&gt;
+	 * <p></p>
 	 * The current user matches DAV:href only if that user is authenticated
 	 * as being (or being a member of) the principal identified by the URL
 	 * contained by that DAV:href.
-	 * <p/>
+	 * <p></p>
 	 * Either a href or one of all,authenticated,unauthenticated,property,self.
-	 * <p/>
+	 * <p></p>
 	 * DAV:property not supported.
 	 */
 	public static enum PrincipalType

--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -273,7 +273,7 @@ public interface Sardine
 	 * the lock from successfully executing a PUT, POST, PROPPATCH, LOCK, UNLOCK, MOVE, DELETE, or MKCOL
 	 * on the locked resource. All other current methods, GET in particular, function
 	 * independently of the lock.
-	 * <p/>
+	 * <p></p>
 	 * A WebDAV compliant server is not required to support locking in any form. If the server does support
 	 * locking it may choose to support any combination of exclusive and shared locks for any access types.
 	 *
@@ -304,7 +304,7 @@ public interface Sardine
 
 	/**
 	 * Unlock the resource.
-	 * <p/>
+	 * <p></p>
 	 * A WebDAV compliant server is not required to support locking in any form. If the server does support
 	 * locking it may choose to support any combination of exclusive and shared locks for any access types.
 	 *
@@ -363,7 +363,7 @@ public interface Sardine
 	/**
 	 * Enables HTTP GZIP compression. If enabled, requests originating from Sardine
 	 * will include "gzip" as an "Accept-Encoding" header.
-	 * <p/>
+	 * <p></p>
 	 * If the server also supports gzip compression, it should serve the
 	 * contents in compressed gzip format and include "gzip" as the
 	 * Content-Encoding. If the content encoding is present, Sardine will

--- a/src/main/java/com/github/sardine/impl/methods/HttpLock.java
+++ b/src/main/java/com/github/sardine/impl/methods/HttpLock.java
@@ -48,7 +48,7 @@ public class HttpLock extends HttpEntityEnclosingRequestBase
 	 * The Depth header may be used with the <code>LOCK</code> method. Values other than <code>0</code> or <code>infinity</code> must not
 	 * be used with the Depth header on a <code>LOCK</code> method. All resources that support the <code>LOCK</code>
 	 * method must support the Depth header.
-	 * <p/>
+	 * <p></p>
 	 * If no Depth header is submitted on a <code>LOCK</code> request then the request must act as if
 	 * a <code>Depth:infinity</code> had been submitted.
 	 *

--- a/src/main/java/com/github/sardine/model/Ace.java
+++ b/src/main/java/com/github/sardine/model/Ace.java
@@ -12,10 +12,10 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- *   &lt;D:owner> 
-          &lt;D:href>http://www.example.com/acl/users/gstein&lt;/D:href>        
-        &lt;/D:owner> 
- * 
+ *   &lt;D:owner&gt;
+ *      &lt;D:href&gt;http://www.example.com/acl/users/gstein&lt;/D:href&gt;
+ *   &lt;/D:owner&gt;
+ * </pre>
  * 
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Acl.java
+++ b/src/main/java/com/github/sardine/model/Acl.java
@@ -13,10 +13,10 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- *   &lt;D:owner> 
-          &lt;D:href>http://www.example.com/acl/users/gstein&lt;/D:href>        
-        &lt;/D:owner> 
- * 
+ *   &lt;D:owner&gt;
+ *      &lt;D:href&gt;http://www.example.com/acl/users/gstein&lt;/D:href&gt;
+ *   &lt;/D:owner&gt;
+ * </pre>
  * 
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Activelock.java
+++ b/src/main/java/com/github/sardine/model/Activelock.java
@@ -21,20 +21,20 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}lockscope"/>
- *         &lt;element ref="{DAV:}locktype"/>
- *         &lt;element ref="{DAV:}depth"/>
- *         &lt;element ref="{DAV:}owner" minOccurs="0"/>
- *         &lt;element ref="{DAV:}timeout" minOccurs="0"/>
- *         &lt;element ref="{DAV:}locktoken" minOccurs="0"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}lockscope"/&gt;
+ *         &lt;element ref="{DAV:}locktype"/&gt;
+ *         &lt;element ref="{DAV:}depth"/&gt;
+ *         &lt;element ref="{DAV:}owner" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}timeout" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}locktoken" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/All.java
+++ b/src/main/java/com/github/sardine/model/All.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Allprop.java
+++ b/src/main/java/com/github/sardine/model/Allprop.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Authenticated.java
+++ b/src/main/java/com/github/sardine/model/Authenticated.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Bind.java
+++ b/src/main/java/com/github/sardine/model/Bind.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Collection.java
+++ b/src/main/java/com/github/sardine/model/Collection.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Creationdate.java
+++ b/src/main/java/com/github/sardine/model/Creationdate.java
@@ -23,14 +23,14 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Deny.java
+++ b/src/main/java/com/github/sardine/model/Deny.java
@@ -24,15 +24,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Displayname.java
+++ b/src/main/java/com/github/sardine/model/Displayname.java
@@ -23,14 +23,14 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Error.java
+++ b/src/main/java/com/github/sardine/model/Error.java
@@ -21,15 +21,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Exclusive.java
+++ b/src/main/java/com/github/sardine/model/Exclusive.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Getcontentlanguage.java
+++ b/src/main/java/com/github/sardine/model/Getcontentlanguage.java
@@ -23,14 +23,14 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Getcontentlength.java
+++ b/src/main/java/com/github/sardine/model/Getcontentlength.java
@@ -23,14 +23,14 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Getcontenttype.java
+++ b/src/main/java/com/github/sardine/model/Getcontenttype.java
@@ -23,14 +23,14 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Getetag.java
+++ b/src/main/java/com/github/sardine/model/Getetag.java
@@ -23,14 +23,14 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Getlastmodified.java
+++ b/src/main/java/com/github/sardine/model/Getlastmodified.java
@@ -23,14 +23,14 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Grant.java
+++ b/src/main/java/com/github/sardine/model/Grant.java
@@ -24,15 +24,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Group.java
+++ b/src/main/java/com/github/sardine/model/Group.java
@@ -24,15 +24,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Keepalive.java
+++ b/src/main/java/com/github/sardine/model/Keepalive.java
@@ -26,15 +26,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}href" maxOccurs="unbounded"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}href" maxOccurs="unbounded"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Link.java
+++ b/src/main/java/com/github/sardine/model/Link.java
@@ -23,16 +23,16 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}src" maxOccurs="unbounded"/>
- *         &lt;element ref="{DAV:}dst" maxOccurs="unbounded"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}src" maxOccurs="unbounded"/&gt;
+ *         &lt;element ref="{DAV:}dst" maxOccurs="unbounded"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Lockdiscovery.java
+++ b/src/main/java/com/github/sardine/model/Lockdiscovery.java
@@ -22,15 +22,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence maxOccurs="unbounded" minOccurs="0">
- *         &lt;element ref="{DAV:}activelock"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence maxOccurs="unbounded" minOccurs="0"&gt;
+ *         &lt;element ref="{DAV:}activelock"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Lockentry.java
+++ b/src/main/java/com/github/sardine/model/Lockentry.java
@@ -21,16 +21,16 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}lockscope"/>
- *         &lt;element ref="{DAV:}locktype"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}lockscope"/&gt;
+ *         &lt;element ref="{DAV:}locktype"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Lockinfo.java
+++ b/src/main/java/com/github/sardine/model/Lockinfo.java
@@ -21,17 +21,17 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}lockscope"/>
- *         &lt;element ref="{DAV:}locktype"/>
- *         &lt;element ref="{DAV:}owner" minOccurs="0"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}lockscope"/&gt;
+ *         &lt;element ref="{DAV:}locktype"/&gt;
+ *         &lt;element ref="{DAV:}owner" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Lockscope.java
+++ b/src/main/java/com/github/sardine/model/Lockscope.java
@@ -20,16 +20,16 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;choice>
- *         &lt;element ref="{DAV:}exclusive"/>
- *         &lt;element ref="{DAV:}shared"/>
- *       &lt;/choice>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice&gt;
+ *         &lt;element ref="{DAV:}exclusive"/&gt;
+ *         &lt;element ref="{DAV:}shared"/&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Locktoken.java
+++ b/src/main/java/com/github/sardine/model/Locktoken.java
@@ -23,15 +23,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}href" maxOccurs="unbounded"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}href" maxOccurs="unbounded"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Locktype.java
+++ b/src/main/java/com/github/sardine/model/Locktype.java
@@ -21,15 +21,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}write"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}write"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Multistatus.java
+++ b/src/main/java/com/github/sardine/model/Multistatus.java
@@ -23,16 +23,16 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}response" maxOccurs="unbounded"/>
- *         &lt;element ref="{DAV:}responsedescription" minOccurs="0"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}response" maxOccurs="unbounded"/&gt;
+ *         &lt;element ref="{DAV:}responsedescription" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Omit.java
+++ b/src/main/java/com/github/sardine/model/Omit.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Owner.java
+++ b/src/main/java/com/github/sardine/model/Owner.java
@@ -24,15 +24,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Principal.java
+++ b/src/main/java/com/github/sardine/model/Principal.java
@@ -20,15 +20,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/PrincipalCollectionSet.java
+++ b/src/main/java/com/github/sardine/model/PrincipalCollectionSet.java
@@ -21,15 +21,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/PrincipalURL.java
+++ b/src/main/java/com/github/sardine/model/PrincipalURL.java
@@ -20,15 +20,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Prop.java
+++ b/src/main/java/com/github/sardine/model/Prop.java
@@ -25,27 +25,27 @@ import org.w3c.dom.Element;
  * <p>The following schema fragment specifies the expected content contained within this class.
  *
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;all>
- *         &lt;element ref="{DAV:}creationdate" minOccurs="0"/>
- *         &lt;element ref="{DAV:}displayname" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getcontentlanguage" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getcontentlength" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getcontenttype" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getetag" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getlastmodified" minOccurs="0"/>
- *         &lt;element ref="{DAV:}lockdiscovery" minOccurs="0"/>
- *         &lt;element ref="{DAV:}resourcetype" minOccurs="0"/>
- *         &lt;element ref="{DAV:}supportedlock" minOccurs="0"/>
- *         &lt;element ref="{DAV:}quota-available-bytes" minOccurs="0"/>
- *         &lt;element ref="{DAV:}quota-used-bytes" minOccurs="0"/>
- *         &lt;any processContents='skip' namespace='##other' maxOccurs="unbounded" minOccurs="0"/>
- *       &lt;/all>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;all&gt;
+ *         &lt;element ref="{DAV:}creationdate" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}displayname" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getcontentlanguage" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getcontentlength" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getcontenttype" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getetag" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getlastmodified" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}lockdiscovery" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}resourcetype" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}supportedlock" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}quota-available-bytes" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}quota-used-bytes" minOccurs="0"/&gt;
+ *         &lt;any processContents='skip' namespace='##other' maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/all&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  *
  *

--- a/src/main/java/com/github/sardine/model/Property.java
+++ b/src/main/java/com/github/sardine/model/Property.java
@@ -24,26 +24,26 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;all>
- *         &lt;element ref="{DAV:}creationdate" minOccurs="0"/>
- *         &lt;element ref="{DAV:}displayname" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getcontentlanguage" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getcontentlength" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getcontenttype" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getetag" minOccurs="0"/>
- *         &lt;element ref="{DAV:}getlastmodified" minOccurs="0"/>
- *         &lt;element ref="{DAV:}lockdiscovery" minOccurs="0"/>
- *         &lt;element ref="{DAV:}resourcetype" minOccurs="0"/>
- *         &lt;element ref="{DAV:}supportedlock" minOccurs="0"/>
- *         &lt;element ref="{DAV:}owner" minOccurs="0"/>  &lt;!-- (for DAV:acl) -->
- *         &lt;any/>
- *       &lt;/all>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;all&gt;
+ *         &lt;element ref="{DAV:}creationdate" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}displayname" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getcontentlanguage" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getcontentlength" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getcontenttype" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getetag" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}getlastmodified" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}lockdiscovery" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}resourcetype" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}supportedlock" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}owner" minOccurs="0"/&gt;  &lt;!-- (for DAV:acl) --&gt;
+ *         &lt;any/&gt;
+ *       &lt;/all&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Propertybehavior.java
+++ b/src/main/java/com/github/sardine/model/Propertybehavior.java
@@ -20,16 +20,16 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;choice>
- *         &lt;element ref="{DAV:}omit"/>
- *         &lt;element ref="{DAV:}keepalive"/>
- *       &lt;/choice>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice&gt;
+ *         &lt;element ref="{DAV:}omit"/&gt;
+ *         &lt;element ref="{DAV:}keepalive"/&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Propertyupdate.java
+++ b/src/main/java/com/github/sardine/model/Propertyupdate.java
@@ -24,16 +24,16 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;choice maxOccurs="unbounded">
- *         &lt;element ref="{DAV:}remove"/>
- *         &lt;element ref="{DAV:}set"/>
- *       &lt;/choice>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice maxOccurs="unbounded"&gt;
+ *         &lt;element ref="{DAV:}remove"/&gt;
+ *         &lt;element ref="{DAV:}set"/&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Propfind.java
+++ b/src/main/java/com/github/sardine/model/Propfind.java
@@ -20,17 +20,17 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;choice>
- *         &lt;element ref="{DAV:}allprop"/>
- *         &lt;element ref="{DAV:}propname"/>
- *         &lt;element ref="{DAV:}prop"/>
- *       &lt;/choice>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice&gt;
+ *         &lt;element ref="{DAV:}allprop"/&gt;
+ *         &lt;element ref="{DAV:}propname"/&gt;
+ *         &lt;element ref="{DAV:}prop"/&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Propname.java
+++ b/src/main/java/com/github/sardine/model/Propname.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Propstat.java
+++ b/src/main/java/com/github/sardine/model/Propstat.java
@@ -21,18 +21,18 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}prop"/>
- *         &lt;element ref="{DAV:}status"/>
- *         &lt;element ref="{DAV:}error" minOccurs="0"/>
- *         &lt;element ref="{DAV:}responsedescription" minOccurs="0"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}prop"/&gt;
+ *         &lt;element ref="{DAV:}status"/&gt;
+ *         &lt;element ref="{DAV:}error" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}responsedescription" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/QuotaAvailableBytes.java
+++ b/src/main/java/com/github/sardine/model/QuotaAvailableBytes.java
@@ -23,14 +23,14 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/QuotaUsedBytes.java
+++ b/src/main/java/com/github/sardine/model/QuotaUsedBytes.java
@@ -23,14 +23,14 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Read.java
+++ b/src/main/java/com/github/sardine/model/Read.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/ReadAcl.java
+++ b/src/main/java/com/github/sardine/model/ReadAcl.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/ReadCurrentUserPrivilegeSet.java
+++ b/src/main/java/com/github/sardine/model/ReadCurrentUserPrivilegeSet.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Remove.java
+++ b/src/main/java/com/github/sardine/model/Remove.java
@@ -21,15 +21,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}prop"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}prop"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Resourcetype.java
+++ b/src/main/java/com/github/sardine/model/Resourcetype.java
@@ -25,16 +25,16 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}collection" minOccurs="0"/>
- *         &lt;any/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}collection" minOccurs="0"/&gt;
+ *         &lt;any/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Response.java
+++ b/src/main/java/com/github/sardine/model/Response.java
@@ -19,29 +19,29 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p/>
+ * </p>
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p/>
+ * </p>
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}href" maxOccurs="unbounded"/>
- *         &lt;choice>
- *           &lt;sequence>
- *             &lt;element ref="{DAV:}status"/>
- *           &lt;/sequence>
- *           &lt;sequence>
- *             &lt;element ref="{DAV:}propstat" maxOccurs="unbounded"/>
- *           &lt;/sequence>
- *         &lt;/choice>
- *         &lt;element ref="{DAV:}error" minOccurs="0"/>
- *         &lt;element ref="{DAV:}responsedescription" minOccurs="0"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}href" maxOccurs="unbounded"/&gt;
+ *         &lt;choice&gt;
+ *           &lt;sequence&gt;
+ *             &lt;element ref="{DAV:}status"/&gt;
+ *           &lt;/sequence&gt;
+ *           &lt;sequence&gt;
+ *             &lt;element ref="{DAV:}propstat" maxOccurs="unbounded"/&gt;
+ *           &lt;/sequence&gt;
+ *         &lt;/choice&gt;
+ *         &lt;element ref="{DAV:}error" minOccurs="0"/&gt;
+ *         &lt;element ref="{DAV:}responsedescription" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -64,21 +64,21 @@ public class Response {
 
     /**
      * Gets the value of the href property.
-     * <p/>
-     * <p/>
+     * <p></p>
+     * <p></p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the href property.
-     * <p/>
-     * <p/>
+     * <p></p>
+     * <p></p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getHref().add(newItem);
      * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
+     * <p></p>
+     * <p></p>
+     * <p></p>
      * Objects of the following type(s) are allowed in the list
      * {@link String }
      */
@@ -111,21 +111,21 @@ public class Response {
 
     /**
      * Gets the value of the propstat property.
-     * <p/>
-     * <p/>
+     * <p></p>
+     * <p></p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the propstat property.
-     * <p/>
-     * <p/>
+     * <p></p>
+     * <p></p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getPropstat().add(newItem);
      * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
+     * <p></p>
+     * <p></p>
+     * <p></p>
      * Objects of the following type(s) are allowed in the list
      * {@link Propstat }
      */

--- a/src/main/java/com/github/sardine/model/SearchRequest.java
+++ b/src/main/java/com/github/sardine/model/SearchRequest.java
@@ -18,11 +18,11 @@ import javax.xml.namespace.QName;
  * this class.
  * 
  * <pre>
-    &lt;element name="searchrequest">
-        &lt;complexType>
-            &lt;any processContents="skip" namespace="##other" minOccurs="1" maxOccurs="1" />
-        &lt;/complexType>
-    &lt;/element>
+ *   &lt;element name="searchrequest"&gt;
+ *       &lt;complexType&gt;
+ *           &lt;any processContents="skip" namespace="##other" minOccurs="1" maxOccurs="1" /&gt;
+ *       &lt;/complexType&gt;
+ *   &lt;/element&gt;
  * </pre>
  */
 @XmlType(name = "")

--- a/src/main/java/com/github/sardine/model/Self.java
+++ b/src/main/java/com/github/sardine/model/Self.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Set.java
+++ b/src/main/java/com/github/sardine/model/Set.java
@@ -21,15 +21,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{DAV:}prop"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element ref="{DAV:}prop"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Shared.java
+++ b/src/main/java/com/github/sardine/model/Shared.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Source.java
+++ b/src/main/java/com/github/sardine/model/Source.java
@@ -22,15 +22,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence maxOccurs="unbounded" minOccurs="0">
- *         &lt;element ref="{DAV:}link"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence maxOccurs="unbounded" minOccurs="0"&gt;
+ *         &lt;element ref="{DAV:}link"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Supportedlock.java
+++ b/src/main/java/com/github/sardine/model/Supportedlock.java
@@ -22,15 +22,15 @@ import java.util.List;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence maxOccurs="unbounded" minOccurs="0">
- *         &lt;element ref="{DAV:}lockentry"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence maxOccurs="unbounded" minOccurs="0"&gt;
+ *         &lt;element ref="{DAV:}lockentry"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/UnBind.java
+++ b/src/main/java/com/github/sardine/model/UnBind.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Unauthenticated.java
+++ b/src/main/java/com/github/sardine/model/Unauthenticated.java
@@ -12,12 +12,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Unlock.java
+++ b/src/main/java/com/github/sardine/model/Unlock.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/Write.java
+++ b/src/main/java/com/github/sardine/model/Write.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/WriteContent.java
+++ b/src/main/java/com/github/sardine/model/WriteContent.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/model/WriteProperties.java
+++ b/src/main/java/com/github/sardine/model/WriteProperties.java
@@ -20,12 +20,12 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/src/main/java/com/github/sardine/util/SardineUtil.java
+++ b/src/main/java/com/github/sardine/util/SardineUtil.java
@@ -252,7 +252,7 @@ public final class SardineUtil
 	/**
 	 * @param jaxbElement An object from the model
 	 * @return The XML string for the WebDAV request
-	 * @throws IOException When there is a JAXB error
+	 * @throws RuntimeException When there is a JAXB error
 	 */
 	public static String toXml(Object jaxbElement)
 	{


### PR DESCRIPTION
Support for building javadocs on Java 8, that introduced a new doclint
feature that does a stricter HTML validation check. 
See https://bugs.openjdk.java.net/browse/JDK-8020619