### PR TITLE
Handle Non-ASCII encoding in the Destination header correctly

### DIFF
--- a/src/main/java/com/github/sardine/impl/methods/HttpCopy.java
+++ b/src/main/java/com/github/sardine/impl/methods/HttpCopy.java
@@ -16,6 +16,7 @@
 
 package com.github.sardine.impl.methods;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpRequestBase;
 
 import java.net.URI;
@@ -30,8 +31,8 @@ public class HttpCopy extends HttpRequestBase
 
 	public HttpCopy(URI sourceUrl, URI destinationUrl)
 	{
-		this.setHeader("Destination", destinationUrl.toString());
-		this.setHeader("Overwrite", "T");
+		this.setHeader(HttpHeaders.DESTINATION, destinationUrl.toASCIIString());
+		this.setHeader(HttpHeaders.OVERWRITE, "T");
 		this.setURI(sourceUrl);
 	}
 

--- a/src/main/java/com/github/sardine/impl/methods/HttpMove.java
+++ b/src/main/java/com/github/sardine/impl/methods/HttpMove.java
@@ -31,7 +31,7 @@ public class HttpMove extends HttpRequestBase
 
 	public HttpMove(URI sourceUrl, URI destinationUrl)
 	{
-		this.setHeader(HttpHeaders.DESTINATION, destinationUrl.toString());
+		this.setHeader(HttpHeaders.DESTINATION, destinationUrl.toASCIIString());
 		this.setHeader(HttpHeaders.OVERWRITE, "T");
 		this.setURI(sourceUrl);
 	}


### PR DESCRIPTION
URI.toASCIIString() instead of URI.toString()
