### PR TITLE
Making overwrite optional for move() and copy()

### DIFF
--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -251,6 +251,16 @@ public interface Sardine
 	void move(String sourceUrl, String destinationUrl) throws IOException;
 
 	/**
+	 * Move a url to from source to destination using WebDAV <code>MOVE</code>.
+	 *
+	 * @param sourceUrl	  Path to the resource including protocol and hostname
+	 * @param destinationUrl Path to the resource including protocol and hostname
+	 * @param overwrite {@code true} to overwrite if the destination exists, {@code false} otherwise.
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	void move(String sourceUrl, String destinationUrl, boolean overwrite) throws IOException;
+
+	/**
 	 * Copy a url from source to destination using WebDAV <code>COPY</code>. Assumes overwrite.
 	 *
 	 * @param sourceUrl	  Path to the resource including protocol and hostname
@@ -258,6 +268,16 @@ public interface Sardine
 	 * @throws IOException I/O error or HTTP response validation failure
 	 */
 	void copy(String sourceUrl, String destinationUrl) throws IOException;
+
+	/**
+	 * Copy a url from source to destination using WebDAV <code>COPY</code>.
+	 *
+	 * @param sourceUrl	  Path to the resource including protocol and hostname
+	 * @param destinationUrl Path to the resource including protocol and hostname
+	 * @param overwrite {@code true} to overwrite if the destination exists, {@code false} otherwise.
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	void copy(String sourceUrl, String destinationUrl, boolean overwrite) throws IOException;
 
 	/**
 	 * Performs a HTTP <code>HEAD</code> request to see if a resource exists or not.

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -860,14 +860,26 @@ public class SardineImpl implements Sardine
 	@Override
 	public void move(String sourceUrl, String destinationUrl) throws IOException
 	{
-		HttpMove move = new HttpMove(sourceUrl, destinationUrl);
+		move(sourceUrl, destinationUrl, true);
+	}
+
+	@Override
+	public void move(String sourceUrl, String destinationUrl, boolean overwrite) throws IOException
+	{
+		HttpMove move = new HttpMove(sourceUrl, destinationUrl, overwrite);
 		this.execute(move, new VoidResponseHandler());
 	}
 
 	@Override
 	public void copy(String sourceUrl, String destinationUrl) throws IOException
 	{
-		HttpCopy copy = new HttpCopy(sourceUrl, destinationUrl);
+		copy(sourceUrl, destinationUrl, true);
+	}
+
+	@Override
+	public void copy(String sourceUrl, String destinationUrl, boolean overwrite) throws IOException
+	{
+		HttpCopy copy = new HttpCopy(sourceUrl, destinationUrl, overwrite);
 		this.execute(copy, new VoidResponseHandler());
 	}
 

--- a/src/main/java/com/github/sardine/impl/methods/HttpCopy.java
+++ b/src/main/java/com/github/sardine/impl/methods/HttpCopy.java
@@ -29,16 +29,16 @@ public class HttpCopy extends HttpRequestBase
 {
 	public static final String METHOD_NAME = "COPY";
 
-	public HttpCopy(URI sourceUrl, URI destinationUrl)
+	public HttpCopy(URI sourceUrl, URI destinationUrl, boolean overwrite)
 	{
 		this.setHeader(HttpHeaders.DESTINATION, destinationUrl.toASCIIString());
-		this.setHeader(HttpHeaders.OVERWRITE, "T");
+		this.setHeader(HttpHeaders.OVERWRITE, overwrite ? "T" : "F");
 		this.setURI(sourceUrl);
 	}
 
-	public HttpCopy(String sourceUrl, String destinationUrl)
+	public HttpCopy(String sourceUrl, String destinationUrl, boolean overwrite)
 	{
-		this(URI.create(sourceUrl), URI.create(destinationUrl));
+		this(URI.create(sourceUrl), URI.create(destinationUrl), overwrite);
 	}
 
 	@Override

--- a/src/main/java/com/github/sardine/impl/methods/HttpMove.java
+++ b/src/main/java/com/github/sardine/impl/methods/HttpMove.java
@@ -29,16 +29,16 @@ public class HttpMove extends HttpRequestBase
 {
 	public static final String METHOD_NAME = "MOVE";
 
-	public HttpMove(URI sourceUrl, URI destinationUrl)
+	public HttpMove(URI sourceUrl, URI destinationUrl, boolean overwrite)
 	{
 		this.setHeader(HttpHeaders.DESTINATION, destinationUrl.toASCIIString());
-		this.setHeader(HttpHeaders.OVERWRITE, "T");
+		this.setHeader(HttpHeaders.OVERWRITE, overwrite ? "T" : "F");
 		this.setURI(sourceUrl);
 	}
 
-	public HttpMove(String sourceUrl, String destinationUrl)
+	public HttpMove(String sourceUrl, String destinationUrl, boolean overwrite)
 	{
-		this(URI.create(sourceUrl), URI.create(destinationUrl));
+		this(URI.create(sourceUrl), URI.create(destinationUrl), overwrite);
 	}
 
 	@Override

--- a/src/test/java/com/github/sardine/FunctionalSardineTest.java
+++ b/src/test/java/com/github/sardine/FunctionalSardineTest.java
@@ -390,9 +390,50 @@ public class FunctionalSardineTest
 		final String destination = "http://sudo.ch/dav/anon/sardine/" + UUID.randomUUID().toString();
 		sardine.put(source, new ByteArrayInputStream("Test".getBytes()));
 		assertTrue(sardine.exists(source));
-		sardine.move(source, destination);
+		sardine.move(source, destination); // implicitly overwrite
 		assertFalse(sardine.exists(source));
 		assertTrue(sardine.exists(destination));
+		sardine.delete(destination);
+	}
+
+	@Test
+	public void testMoveOverwriting() throws Exception
+	{
+		Sardine sardine = SardineFactory.begin();
+		final String source = "http://sudo.ch/dav/anon/sardine/" + UUID.randomUUID().toString();
+		final String destination = "http://sudo.ch/dav/anon/sardine/" + UUID.randomUUID().toString();
+		sardine.put(source, new ByteArrayInputStream("Test".getBytes()));
+		assertTrue(sardine.exists(source));
+		sardine.put(destination, new ByteArrayInputStream("Target".getBytes()));
+		assertTrue(sardine.exists(destination));
+		sardine.move(source, destination, true);
+		assertFalse(sardine.exists(source));
+		assertTrue(sardine.exists(destination));
+		sardine.delete(destination);
+	}
+
+	@Test
+	public void testMoveFailOnExisting() throws Exception
+	{
+		Sardine sardine = SardineFactory.begin();
+		final String source = "http://sudo.ch/dav/anon/sardine/" + UUID.randomUUID().toString();
+		final String destination = "http://sudo.ch/dav/anon/sardine/" + UUID.randomUUID().toString();
+		sardine.put(source, new ByteArrayInputStream("Test".getBytes()));
+		assertTrue(sardine.exists(source));
+		sardine.put(destination, new ByteArrayInputStream("Safe".getBytes()));
+		assertTrue(sardine.exists(destination));
+		try
+		{
+			sardine.move(source, destination, false);
+			fail("Expected SardineException");
+		}
+		catch (SardineException e)
+		{
+			assertEquals(412, e.getStatusCode());
+		}
+		assertTrue(sardine.exists(source));
+		assertTrue(sardine.exists(destination));
+		sardine.delete(source);
 		sardine.delete(destination);
 	}
 


### PR DESCRIPTION
Our own filesystem abstraction only has rename(String,String), but took the safe route of defaulting to failing if the destination file exists. At the moment, Sardine has move(String,String) but it defaults to overwrite.

This patch adds an overload with an additional boolean flag to specify whether to overwrite or not. It doesn't do a lot more than that - for instance, someone might prefer specific exceptions for these 412 errors, but it doesn't seem like we get a specific exception for 404 either, so at least it's consistent.

I added the missing test cases for move but didn't see a test case for copy so left it alone. All the tests failed for me anyway... possibly because they appear to depend on a real server.
