### PR TITLE
Fix for Issue #201 (Ant NTLM authorization) and two other encountered issues.

### DIFF
--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -412,6 +412,11 @@ public interface Sardine
 	void disableCompression();
 
 	/**
+	 * Ignores cookies.
+	 */
+	public void ignoreCookies();
+
+	/**
 	 * Send a <code>Basic</code> authentication header with each request even before 401 is returned.
 	 * Uses default ports: 80 for http and 443 for https
 	 *

--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -214,10 +214,10 @@ public interface Sardine
 	 * @throws IOException I/O error or HTTP response validation failure
 	 */
 	void put(String url, InputStream dataStream, Map<String, String> headers) throws IOException;
-        
+
 	/**
 	 * Uses <code>PUT</code> to upload file to a server with specific contentType. 
-         * Repeatable on authentication failure.
+	 * Repeatable on authentication failure.
 	 *
 	 * @param url		Path to the resource including protocol and hostname
 	 * @param localFile local file to send
@@ -225,6 +225,19 @@ public interface Sardine
 	 * @throws IOException I/O error or HTTP response validation failure
 	 */
 	void put(String url, File localFile, String contentType) throws IOException;
+
+	/**
+	 * Uses <code>PUT</code> to upload file to a server with specific contentType. 
+	 * Repeatable on authentication failure.
+	 *
+	 * @param url       Path to the resource including protocol and hostname
+	 * @param localFile local file to send
+	 * @param contentType   MIME type to add to the HTTP request header
+	 * @param expectContinue Enable <code>Expect: continue</code> header for <code>PUT</code> requests.
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	void put(String url, File localFile, String contentType, boolean expectContinue) throws IOException;
+
 	/**
 	 * Delete a resource using HTTP <code>DELETE</code> at the specified url
 	 *

--- a/src/main/java/com/github/sardine/ant/SardineTask.java
+++ b/src/main/java/com/github/sardine/ant/SardineTask.java
@@ -23,31 +23,31 @@ import com.github.sardine.ant.command.Put;
 public class SardineTask extends Task
 {
 	/** Commands. */
-	private List<Command> fCommands = new ArrayList<Command>();
+	private List<Command> commands = new ArrayList<Command>();
 
 	/** Attribute failOnError. */
-	private boolean fFailOnError = false;
+	private boolean failOnError = false;
 
 	/** Attribute username. */
-	private String fUsername = null;
+	private String username = null;
 
 	/** Attribute password. */
-	private String fPassword = null;
+	private String password = null;
 
 	/** Attribute domain for NTLM authentication. */
-	private String fDomain = null;
+	private String domain = null;
 
 	/** Attribute workstation for NTLM authentication. */
-	private String fWorkstation = null;
+	private String workstation = null;
 
 	/** Attribute ignoreCookies. */
-	private boolean fIgnoreCookies = false;
+	private boolean ignoreCookies = false;
 
 	/** Attribute preemptiveAuthenticationHost. */
-	private String fPreemptiveAuthenticationHost;
+	private String preemptiveAuthenticationHost;
 
 	/** Reference to sardine impl. */
-	private Sardine fSardine = null;
+	private Sardine sardine = null;
 
 	/** Add a copy command. */
 	public void addCopy(Copy copy) {
@@ -82,7 +82,7 @@ public class SardineTask extends Task
 	/** Internal addCommand implementation. */
 	private void addCommand(Command command) {
 		command.setTask(this);
-		fCommands.add(command);
+		commands.add(command);
 	}
 
 	/**
@@ -91,22 +91,22 @@ public class SardineTask extends Task
 	@Override
 	public void execute() throws BuildException {
 		try {
-			if ( fDomain==null && fWorkstation==null ) {
-				fSardine = SardineFactory.begin(fUsername, fPassword);
+			if (domain == null && workstation == null) {
+				sardine = SardineFactory.begin(username, password);
 			} else {
-				fSardine = SardineFactory.begin();
-				fSardine.setCredentials(fUsername, fPassword, fDomain, fWorkstation);
+				sardine = SardineFactory.begin();
+				sardine.setCredentials(username, password, domain, workstation);
 			}
 
-			if (fIgnoreCookies) {
-				fSardine.ignoreCookies();
+			if (ignoreCookies) {
+				sardine.ignoreCookies();
 			}
 
-			if (fPreemptiveAuthenticationHost != null && !fPreemptiveAuthenticationHost.isEmpty()) {
-				fSardine.enablePreemptiveAuthentication(fPreemptiveAuthenticationHost);
+			if (preemptiveAuthenticationHost != null && !preemptiveAuthenticationHost.isEmpty()) {
+				sardine.enablePreemptiveAuthentication(preemptiveAuthenticationHost);
 			}
 
-			for (Command command: fCommands) {
+			for (Command command: commands) {
 				command.executeCommand();
 			}
 		} catch (Exception e) {
@@ -121,7 +121,7 @@ public class SardineTask extends Task
 	 *        and continue
 	 */
 	public void setFailonerror(boolean failonerror) {
-		fFailOnError = failonerror;
+		this.failOnError = failonerror;
 	}
 
 	/**
@@ -131,7 +131,7 @@ public class SardineTask extends Task
 	 *         continue
 	 */
 	public boolean isFailonerror() {
-		return fFailOnError;
+		return failOnError;
 	}
 
 	/**
@@ -140,7 +140,7 @@ public class SardineTask extends Task
 	 * @param username used for authentication
 	 */
 	public void setUsername(String username) {
-		fUsername = username;
+		this.username = username;
 	}
 
 	/**
@@ -149,7 +149,7 @@ public class SardineTask extends Task
 	 * @param password used for authentication
 	 */
 	public void setPassword(String password) {
-		fPassword = password;
+		this.password = password;
 	}
 	
 	/**
@@ -158,7 +158,7 @@ public class SardineTask extends Task
 	 * @param domain used for NTLM authentication
 	 */
 	public void setDomain(String domain) {
-		fDomain = domain;
+		this.domain = domain;
 	}
 
 	/**
@@ -167,7 +167,7 @@ public class SardineTask extends Task
 	 * @param workstation used for NTLM authentication
 	 */
 	public void setWorkstation(String workstation) {
-		fWorkstation = workstation;
+		this.workstation = workstation;
 	}
 
 	/**
@@ -176,7 +176,7 @@ public class SardineTask extends Task
 	 * @param Whether to ignore cookies.
 	 */
 	public void setIgnoreCookies(boolean ignoreCookies) {
-		fIgnoreCookies = ignoreCookies;
+		this.ignoreCookies = ignoreCookies;
 	}
 
 	/**
@@ -185,7 +185,7 @@ public class SardineTask extends Task
 	 * @param host name of the host to acivate the preemptive authentication for
 	 */
 	public void setPreemptiveAuthenticationHost(String host) {
-		fPreemptiveAuthenticationHost = host;
+		this.preemptiveAuthenticationHost = host;
 	}
 
 	/**
@@ -194,6 +194,6 @@ public class SardineTask extends Task
 	 * @return the sardine impl
 	 */
 	public Sardine getSardine() {
-		return fSardine;
+		return sardine;
 	}
 }

--- a/src/main/java/com/github/sardine/ant/SardineTask.java
+++ b/src/main/java/com/github/sardine/ant/SardineTask.java
@@ -34,6 +34,12 @@ public class SardineTask extends Task
 	/** Attribute password. */
 	private String fPassword = null;
 
+	/** Attribute domain for NTLM authentication. */
+	private String fDomain = null;
+
+	/** Attribute workstation for NTLM authentication. */
+	private String fWorkstation = null;
+
 	/** Attribute preemptiveAuthenticationHost. */
 	private String fPreemptiveAuthenticationHost;
 
@@ -82,7 +88,13 @@ public class SardineTask extends Task
 	@Override
 	public void execute() throws BuildException {
 		try {
-			fSardine = SardineFactory.begin(fUsername, fPassword);
+			if ( fDomain==null && fWorkstation==null ) {
+				fSardine = SardineFactory.begin(fUsername, fPassword);
+			} else {
+				fSardine = SardineFactory.begin();
+				fSardine.setCredentials(fUsername, fPassword, fDomain, fWorkstation);
+			}
+
 			if (fPreemptiveAuthenticationHost != null && !fPreemptiveAuthenticationHost.isEmpty()) {
 				fSardine.enablePreemptiveAuthentication(fPreemptiveAuthenticationHost);
 			}
@@ -131,6 +143,24 @@ public class SardineTask extends Task
 	 */
 	public void setPassword(String password) {
 		fPassword = password;
+	}
+	
+	/**
+	 * Setter for attribute domain for NTLM authentication.
+	 *
+	 * @param domain used for NTLM authentication
+	 */
+	public void setDomain(String domain) {
+		fDomain = domain;
+	}
+
+	/**
+	 * Setter for attribute workstation for NTLM authentication.
+	 *
+	 * @param workstation used for NTLM authentication
+	 */
+	public void setWorkstation(String workstation) {
+		fWorkstation = workstation;
 	}
 
 	/**

--- a/src/main/java/com/github/sardine/ant/SardineTask.java
+++ b/src/main/java/com/github/sardine/ant/SardineTask.java
@@ -40,6 +40,9 @@ public class SardineTask extends Task
 	/** Attribute workstation for NTLM authentication. */
 	private String fWorkstation = null;
 
+	/** Attribute ignoreCookies. */
+	private boolean fIgnoreCookies = false;
+
 	/** Attribute preemptiveAuthenticationHost. */
 	private String fPreemptiveAuthenticationHost;
 
@@ -93,6 +96,10 @@ public class SardineTask extends Task
 			} else {
 				fSardine = SardineFactory.begin();
 				fSardine.setCredentials(fUsername, fPassword, fDomain, fWorkstation);
+			}
+
+			if (fIgnoreCookies) {
+				fSardine.ignoreCookies();
 			}
 
 			if (fPreemptiveAuthenticationHost != null && !fPreemptiveAuthenticationHost.isEmpty()) {
@@ -161,6 +168,15 @@ public class SardineTask extends Task
 	 */
 	public void setWorkstation(String workstation) {
 		fWorkstation = workstation;
+	}
+
+	/**
+	 * Setter for attribute ignoreCookies.
+	 *
+	 * @param Whether to ignore cookies.
+	 */
+	public void setIgnoreCookies(boolean ignoreCookies) {
+		fIgnoreCookies = ignoreCookies;
 	}
 
 	/**

--- a/src/main/java/com/github/sardine/ant/command/Put.java
+++ b/src/main/java/com/github/sardine/ant/command/Put.java
@@ -111,7 +111,7 @@ public class Put extends Command {
 	 */
 	private void process(File file, URL dest, boolean expectContinue) throws Exception {
 		log("putting " + file + " to " + dest + " with expectContinue=" + expectContinue, Project.MSG_VERBOSE);
-		getSardine().put(dest.toString(), new FileInputStream(file), fContentType, expectContinue);
+		getSardine().put(dest.toString(), file, fContentType, expectContinue);
 	}
 
 	/**

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -845,12 +845,19 @@ public class SardineImpl implements Sardine
 			throw e;
 		}
 	}
-        @Override
-        public void put(String url, File localFile, String contentType) throws IOException {
-                FileEntity content = new FileEntity(localFile);
-                //don't use ExpectContinue for repetable FileEntity, some web server (IIS for exmaple) may return 400 bad request after retry
-                this.put(url, content, contentType, false);
-        }
+
+	@Override
+	public void put(String url, File localFile, String contentType) throws IOException {
+		//don't use ExpectContinue for repetable FileEntity, some web server (IIS for exmaple) may return 400 bad request after retry
+		put(url, localFile, contentType, false);
+	}
+
+	@Override
+	public void put(String url, File localFile, String contentType, boolean expectContinue) throws IOException {
+		FileEntity content = new FileEntity(localFile);
+		this.put(url, content, contentType, expectContinue);
+	}
+
 	@Override
 	public void delete(String url) throws IOException
 	{

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -93,6 +93,7 @@ import org.apache.http.client.params.AuthPolicy;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.protocol.RequestAcceptEncoding;
 import org.apache.http.client.protocol.ResponseContentEncoding;
+import org.apache.http.config.Lookup;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
@@ -101,6 +102,7 @@ import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
@@ -113,6 +115,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.DefaultSchemePortResolver;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.apache.http.impl.cookie.IgnoreSpecFactory;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.util.VersionInfo;
@@ -281,6 +284,21 @@ public class SardineImpl implements Sardine
 	public void disableCompression()
 	{
 		this.builder.disableContentCompression();
+		this.client = this.builder.build();
+	}
+
+	/**
+	 * Ignores cookies by always returning the IgnoreSpecFactory regardless of the cookieSpec value being looked up.
+	 */
+	@Override
+	public void ignoreCookies()
+	{
+		this.builder.setDefaultCookieSpecRegistry(new Lookup<CookieSpecProvider>() {
+			@Override
+			public CookieSpecProvider lookup(String name) {
+				return new IgnoreSpecFactory();
+			}
+		});
 		this.client = this.builder.build();
 	}
 


### PR DESCRIPTION
Fixes for the following;
(a) Commit #1 - Issue #201 - Extend the Ant SardineTask to work for NTLM authentication by allowing users to specify a "domain" and "workstation" attribute to the "Sardine" ant task.
   Ant Task Example: <sardine domain="domain" username="user" password="pass" workstation="workstation">...</sardine>
(b) Commit #2 - Ant "Put" command fails because Sharepoint expects to be repeatable - yet because the Ant "Put" command wraps the file in "new FileInputStream(file)" it's not repeatable and causes the put to fail. The commit also adds a "put(url,localFile,contentType,*expectContinue*)" method which is missing from the "Sardine" interface, but should really probably be there.
(c) Commit #3 - Adds an "ignoreCookies()" method to the "Sardine" interface - additionally adds support for this to the Ant "SardineTask". This functionality is added because HttpClient logs a large number of warnings for Sharepoint cookies which can simply be ignored - this is a quick fix that can no doubt be extended in the future to support more types of behaviors with cookies.
   Ant Task Example: <sardine ignoreCookies="true">...</sardine>