### PR TITLE
Fix #208

### DIFF
--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -4,6 +4,8 @@ import java.io.File;
 
 import javax.xml.namespace.QName;
 
+import org.w3c.dom.Element;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -119,6 +121,17 @@ public interface Sardine
 	 * @throws IOException I/O error or HTTP response validation failure
 	 */
 	List<DavResource> patch(String url, Map<QName, String> addProps, List<QName> removeProps) throws IOException;
+
+	/**
+	 * Add or remove custom properties for a url using WebDAV <code>PROPPATCH</code>.
+	 *
+	 * @param url		 Path to the resource including protocol and hostname
+	 * @param addProps	Properties to add to resource. If a property already exists then its value is replaced.
+	 * @param removeProps Properties to remove from resource. Specifying the removal of a property that does not exist is not an error.
+	 * @return The patched resources from the response
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	List<DavResource> patch(String url, List<Element> addProps, List<QName> removeProps) throws IOException;
 
 	/**
 	 * Uses HTTP <code>GET</code> to download data from a server. The stream must be closed after reading.

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -122,6 +122,7 @@ import org.apache.http.util.VersionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 import javax.xml.namespace.QName;
 
@@ -134,6 +135,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.http.entity.FileEntity;
 
@@ -474,6 +476,23 @@ public class SardineImpl implements Sardine
 	@Override
 	public List<DavResource> patch(String url, Map<QName, String> setProps, List<QName> removeProps) throws IOException
 	{
+		List<Element> setPropsElements = new ArrayList<Element>();
+		for (Entry<QName, String> entry : setProps.entrySet()) {
+			Element element = SardineUtil.createElement(entry.getKey());
+			element.setTextContent(entry.getValue());
+			setPropsElements.add(element);
+		}
+		return this.patch(url, setPropsElements, removeProps);
+	}
+
+	/**
+	 * Creates a {@link com.github.sardine.model.Propertyupdate} element containing all properties to set from setProps and all properties to
+	 * remove from removeProps. Note this method will use a {@link com.github.sardine.util.SardineUtil#CUSTOM_NAMESPACE_URI} as
+	 * namespace and {@link com.github.sardine.util.SardineUtil#CUSTOM_NAMESPACE_PREFIX} as prefix.
+	 */
+	@Override
+	public List<DavResource> patch(String url, List<Element> setProps, List<QName> removeProps) throws IOException
+	{
 		HttpPropPatch entity = new HttpPropPatch(url);
 		// Build WebDAV <code>PROPPATCH</code> entity.
 		Propertyupdate body = new Propertyupdate();
@@ -484,10 +503,8 @@ public class SardineImpl implements Sardine
 			Prop prop = new Prop();
 			// Returns a reference to the live list
 			List<Element> any = prop.getAny();
-			for (Map.Entry<QName, String> entry : setProps.entrySet())
+			for (Element element : setProps)
 			{
-				Element element = SardineUtil.createElement(entry.getKey());
-				element.setTextContent(entry.getValue());
 				any.add(element);
 			}
 			set.setProp(prop);

--- a/src/main/java/com/github/sardine/util/SardineUtil.java
+++ b/src/main/java/com/github/sardine/util/SardineUtil.java
@@ -322,4 +322,12 @@ public final class SardineUtil
 	{
 		return createDocument().createElementNS(key.getNamespaceURI(), key.getPrefix() + ":" + key.getLocalPart());
 	}
+
+	/**
+	 * @param key Fully qualified element name.
+	 */
+	public static Element createElement(Element parent, QName key)
+	{
+		return parent.getOwnerDocument().createElementNS(key.getNamespaceURI(), key.getPrefix() + ":" + key.getLocalPart());
+	}
 }

--- a/src/test/java/com/github/sardine/LockTest.java
+++ b/src/test/java/com/github/sardine/LockTest.java
@@ -76,7 +76,7 @@ public class LockTest
 	{
 		Sardine sardine = SardineFactory.begin();
 
-		String existingFile = "0be720f6-2013-46f2-a369-a7e2df047ef8";
+		String existingFile = "5bac62e9-d233-438b-8d45-4c8ceb8d3069";
 		String existingFileUrl = "http://test.cyberduck.ch/dav/anon/sardine/" + existingFile;
 
 		String lockToken = sardine.lock(existingFileUrl);


### PR DESCRIPTION
Fix #208.

This patch leaves the possibility to use a `Map<QName, String>`, but it is now possible to use directly a list of `org.w3c.dom.Element`.

Example:
```java
final QName qnameTags = new QName("http://owncloud.org/ns", "tags", "oc");
final Element tags = SardineUtil.createElement(qnameTags);
final QName qnameTag = new QName("http://owncloud.org/ns", "tag", "oc");
final Element tag1 = SardineUtil.createElement(tags, qnameTag);
tag1.setTextContent("tag1");
tags.appendChild(tag1);
final Element tag2 = SardineUtil.createElement(tags, qnameTag);
tag2.setTextContent("tag2");
tags.appendChild(tag2);

final QName qnameFavorite = new QName("http://owncloud.org/ns", "favorite", "oc");
final Element favorite = SardineUtil.createElement(qnameFavorite);
favorite.setTextContent("1");

final List<Element> addProps = ImmutableList.of(tags, favorite);
sardine.patch(url, addProps, Collections.<QName> emptyList());
```

will generate:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<propertyupdate xmlns="DAV:">
  <set>
    <prop>
      <oc:tags xmlns:oc="http://owncloud.org/ns">
        <oc:tag>tag1</oc:tag>
        <oc:tag>tag2</oc:tag>
      </oc:tags>
      <oc:favorite xmlns:oc="http://owncloud.org/ns">1</oc:favorite>
    </prop>
  </set>
  <remove>
    <prop/>
  </remove>
</propertyupdate>
```
