### PR TITLE
Premature request abort fails PUT through an HTTP proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,16 @@
 		</license>
 	</licenses>
 	<scm>
-		<connection>scm:git:git@github.com:lookfirst/sardine.git</connection>
-		<developerConnection>scm:git:git@github.com:lookfirst/sardine.git</developerConnection>
-		<url>git@github.com:lookfirst/sardine.git</url>
+		<connection>scm:git:git@github.com:chadlyon/sardine.git</connection>
+		<developerConnection>scm:git:git@github.com:chadlyon/sardine.git</developerConnection>
+		<url>git@github.com:chadlyon/sardine.git</url>
 	</scm>
 	<developers>
+		<developer>
+			<name>Chad Lyon</name>
+			<id>chadlyon</id>
+			<email>chad.lyon@gmail.com</email>
+		</developer>
 		<developer>
 			<name>Jon Stevens</name>
 			<id>lookfirst</id>

--- a/pom.xml
+++ b/pom.xml
@@ -42,16 +42,16 @@
 		</developer>
 	</developers>
   	<distributionManagement>
-		<repository>
-			<id>nexus-releases</id>
-			<name>Nexus Release Repository</name>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-		</repository>
-		<snapshotRepository>
-			<id>sonatype-nexus-snapshots</id>
-			<name>Sonatype Nexus snapshot repository</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
+	  <repository>
+	    <id>opala-2014</id>
+	    <name>opala-2014-releases</name>
+	    <url>http://maven.compass.chalybs.net:8081/artifactory/compass-thirdparty-forks-releases</url>
+	  </repository>
+	  <snapshotRepository>
+	    <id>opala-2014</id>
+	    <name>opala-2014-snapshots</name>
+	    <url>http://maven.compass.chalybs.net:8081/artifactory/compass-thirdparty-forks-snapshots</url>
+	  </snapshotRepository>
 	</distributionManagement>
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.github.lookfirst</groupId>
 	<artifactId>sardine</artifactId>
 	<packaging>jar</packaging>
-	<version>5.5-rc1</version>
+	<version>5.5-SNAPSHOT</version>
 	<description>An easy to use webdav client for java</description>
 	<name>Sardine WEBDAV client</name>
 	<url>https://github.com/lookfirst/sardine</url>

--- a/pom.xml
+++ b/pom.xml
@@ -43,13 +43,13 @@
 	</developers>
   	<distributionManagement>
 	  <repository>
-	    <id>opala-2014</id>
-	    <name>opala-2014-releases</name>
+	    <id>compass-thirdparty-forks</id>
+	    <name>compass-thirdparty-forks-releases</name>
 	    <url>http://maven.compass.chalybs.net:8081/artifactory/compass-thirdparty-forks-releases</url>
 	  </repository>
 	  <snapshotRepository>
-	    <id>opala-2014</id>
-	    <name>opala-2014-snapshots</name>
+	    <id>compass-thirdparty-forks</id>
+	    <name>compass-thirdparty-forks-snapshots</name>
 	    <url>http://maven.compass.chalybs.net:8081/artifactory/compass-thirdparty-forks-snapshots</url>
 	  </snapshotRepository>
 	</distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -79,32 +79,44 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.2.1</version>
-				<executions>
-				  <execution>
-				    <id>attach-sources</id>
-				    <goals>
-				      <goal>jar</goal>
-				    </goals>
-				  </execution>
-				</executions>
+			  <groupId>org.apache.maven.plugins</groupId>
+			  <artifactId>maven-source-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
-				<executions>
-				  <execution>
-				    <id>attach-javadocs</id>
-				    <goals>
-				      <goal>jar</goal>
-				    </goals>
-				  </execution>
-				</executions>
+			  <groupId>org.apache.maven.plugins</groupId>
+			  <artifactId>maven-javadoc-plugin</artifactId>
 			</plugin>
 		</plugins>
+		<pluginManagement>
+		  <plugins>
+		    <plugin>
+		      <groupId>org.apache.maven.plugins</groupId>
+		      <artifactId>maven-source-plugin</artifactId>
+		      <version>2.2.1</version>
+		      <executions>
+			<execution>
+			  <id>attach-sources</id>
+			  <goals>
+			    <goal>jar</goal>
+			  </goals>
+			</execution>
+		      </executions>
+		    </plugin>
+		    <plugin>
+		      <groupId>org.apache.maven.plugins</groupId>
+		      <artifactId>maven-javadoc-plugin</artifactId>
+		      <version>2.9.1</version>
+		      <executions>
+			<execution>
+			  <id>attach-javadocs</id>
+			  <goals>
+			    <goal>jar</goal>
+			  </goals>
+			</execution>
+		      </executions>
+		    </plugin>
+		  </plugins>
+		</pluginManagement>
 	</build>
 	<profiles>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.github.lookfirst</groupId>
 	<artifactId>sardine</artifactId>
 	<packaging>jar</packaging>
-	<version>5.5-SNAPSHOT</version>
+	<version>5.5-rc1</version>
 	<description>An easy to use webdav client for java</description>
 	<name>Sardine WEBDAV client</name>
 	<url>https://github.com/lookfirst/sardine</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.github.lookfirst</groupId>
 	<artifactId>sardine</artifactId>
 	<packaging>jar</packaging>
-	<version>5.5-Comcast-rc1</version>
+	<version>5.5-Comcast-SNAPSHOT</version>
 	<description>An easy to use webdav client for java</description>
 	<name>Sardine WEBDAV client</name>
 	<url>https://github.com/lookfirst/sardine</url>

--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,12 @@
 				<artifactId>maven-source-plugin</artifactId>
 				<version>2.2.1</version>
 				<executions>
-					<execution>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
+				  <execution>
+				    <id>attach-sources</id>
+				    <goals>
+				      <goal>jar</goal>
+				    </goals>
+				  </execution>
 				</executions>
 			</plugin>
 			<plugin>
@@ -95,11 +96,12 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.9.1</version>
 				<executions>
-					<execution>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
+				  <execution>
+				    <id>attach-javadocs</id>
+				    <goals>
+				      <goal>jar</goal>
+				    </goals>
+				  </execution>
 				</executions>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.github.lookfirst</groupId>
 	<artifactId>sardine</artifactId>
 	<packaging>jar</packaging>
-	<version>5.5-Comcast-SNAPSHOT</version>
+	<version>5.5-Comcast-rc1</version>
 	<description>An easy to use webdav client for java</description>
 	<name>Sardine WEBDAV client</name>
 	<url>https://github.com/lookfirst/sardine</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.github.lookfirst</groupId>
 	<artifactId>sardine</artifactId>
 	<packaging>jar</packaging>
-	<version>5.5-SNAPSHOT</version>
+	<version>5.5-Comcast-rc1</version>
 	<description>An easy to use webdav client for java</description>
 	<name>Sardine WEBDAV client</name>
 	<url>https://github.com/lookfirst/sardine</url>

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -869,7 +869,8 @@ public class SardineImpl implements Sardine
 		}
 		try
 		{
-			return this.execute(put, handler);
+			this.context.removeAttribute(HttpClientContext.REDIRECT_LOCATIONS);
+			return this.client.execute(put, handler, this.context);
 		}
 		catch (HttpResponseException e)
 		{


### PR DESCRIPTION
I noticed that when trying to use sardine through an http proxy directory creations were succeeding but PUTs were failing strangely. I dug in and noticed that after the proxy responded with "HTTP/1.0 417 Expectation Failed" Sardine aborted the request and didn't subsequently retry the request without the Expect header. FYI my proxy is "Server: squid/3.1.8" if you want to try to reproduce.