### PR TITLE
Premature request abort fails PUT through an HTTP proxy

### DIFF
--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -869,7 +869,8 @@ public class SardineImpl implements Sardine
 		}
 		try
 		{
-			return this.execute(put, handler);
+			this.context.removeAttribute(HttpClientContext.REDIRECT_LOCATIONS);
+			return this.client.execute(put, handler, this.context);
 		}
 		catch (HttpResponseException e)
 		{

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -965,6 +965,7 @@ public class SardineImpl implements Sardine
 		}
 		catch (HttpResponseException e)
         {
+		    // Don't abort if we get this exception, caller may want to repeat request.
 		    throw e;
         }
 		catch (IOException e)
@@ -992,6 +993,7 @@ public class SardineImpl implements Sardine
 		}
 		catch (HttpResponseException e)
         {
+		    // Don't abort if we get this exception, caller may want to repeat request.
             throw e;
         }
 		catch (IOException e)

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -869,8 +869,7 @@ public class SardineImpl implements Sardine
 		}
 		try
 		{
-			this.context.removeAttribute(HttpClientContext.REDIRECT_LOCATIONS);
-			return this.client.execute(put, handler, this.context);
+			return this.execute(put, handler);
 		}
 		catch (HttpResponseException e)
 		{
@@ -964,6 +963,10 @@ public class SardineImpl implements Sardine
 			// Execute with response handler
 			return this.client.execute(request, responseHandler, this.context);
 		}
+		catch (HttpResponseException e)
+        {
+		    throw e;
+        }
 		catch (IOException e)
 		{
 			request.abort();
@@ -987,6 +990,10 @@ public class SardineImpl implements Sardine
 			// Execute with no response handler
 			return this.client.execute(request, this.context);
 		}
+		catch (HttpResponseException e)
+        {
+            throw e;
+        }
 		catch (IOException e)
 		{
 			request.abort();

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -963,11 +963,10 @@ public class SardineImpl implements Sardine
 			// Execute with response handler
 			return this.client.execute(request, responseHandler, this.context);
 		}
-		catch (HttpResponseException e)
-        {
-		    // Don't abort if we get this exception, caller may want to repeat request.
-		    throw e;
-        }
+		catch (HttpResponseException e) {
+			// Don't abort if we get this exception, caller may want to repeat request.
+			throw e;
+		}
 		catch (IOException e)
 		{
 			request.abort();
@@ -992,10 +991,10 @@ public class SardineImpl implements Sardine
 			return this.client.execute(request, this.context);
 		}
 		catch (HttpResponseException e)
-        {
-		    // Don't abort if we get this exception, caller may want to repeat request.
-            throw e;
-        }
+		{
+			// Don't abort if we get this exception, caller may want to repeat request.
+			throw e;
+		}
 		catch (IOException e)
 		{
 			request.abort();


### PR DESCRIPTION
I noticed that when trying to use sardine through an http proxy directory creations were succeeding but PUTs were failing strangely. I dug in and noticed that after the proxy responded with "HTTP/1.0 417 Expectation Failed" Sardine aborted the request and didn't subsequently retry the request without the Expect header. FYI my proxy is "Server: squid/3.1.8" if you want to try to reproduce.