### PR TITLE
Replace SLF4J with java.util.logging (JUL) as SLF4J can cause issues with other libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,11 +137,6 @@
 			<artifactId>httpclient</artifactId>
 			<version>4.4.1</version>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.12</version>
-		</dependency>
 		<!-- ant and junit must be defined as provided for a successful compile. -->
 		<dependency>
 			<groupId>org.apache.ant</groupId>
@@ -160,12 +155,6 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>1.10.19</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<version>1.7.12</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/github/sardine/DavResource.java
+++ b/src/main/java/com/github/sardine/DavResource.java
@@ -18,8 +18,6 @@ import com.github.sardine.model.Propstat;
 import com.github.sardine.model.Resourcetype;
 import com.github.sardine.model.Response;
 import com.github.sardine.util.SardineUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
 import javax.xml.namespace.QName;
@@ -29,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * Describes a resource on a remote server. This could be a directory or an actual file.
@@ -37,7 +36,7 @@ import java.util.Map;
  */
 public class DavResource
 {
-	private static Logger log = LoggerFactory.getLogger(DavResource.class);
+	private static final Logger log = Logger.getLogger(DavResource.class.getName());
 
 	/**
 	 * The default content-type if {@link Getcontenttype} is not set in
@@ -225,7 +224,7 @@ public class DavResource
 					}
 					catch (NumberFormatException e)
 					{
-						log.warn(String.format("Failed to parse content length %s", gcl.getContent().get(0)));
+						log.warning(String.format("Failed to parse content length %s", gcl.getContent().get(0)));
 					}
 				}
 			}
@@ -488,7 +487,7 @@ public class DavResource
 		}
 		catch (StringIndexOutOfBoundsException e)
 		{
-			log.warn(String.format("Failed to parse name from path %s", path));
+			log.warning(String.format("Failed to parse name from path %s", path));
 			return null;
 		}
 	}

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -119,10 +119,7 @@ import org.apache.http.impl.cookie.IgnoreSpecFactory;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.util.VersionInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 import javax.xml.namespace.QName;
 
@@ -136,6 +133,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Logger;
 
 import org.apache.http.entity.FileEntity;
 
@@ -146,7 +144,7 @@ import org.apache.http.entity.FileEntity;
  */
 public class SardineImpl implements Sardine
 {
-	private static Logger log = LoggerFactory.getLogger(DavResource.class);
+	private static final Logger log = Logger.getLogger(DavResource.class.getName());
 
 	private static final String UTF_8 = "UTF-8";
 
@@ -427,7 +425,7 @@ public class SardineImpl implements Sardine
 			}
 			catch (URISyntaxException e)
 			{
-				log.warn(String.format("Ignore resource with invalid URI %s", response.getHref().get(0)));
+				log.warning(String.format("Ignore resource with invalid URI %s", response.getHref().get(0)));
 			}
 		}
 		return resources;
@@ -450,7 +448,7 @@ public class SardineImpl implements Sardine
 			}
 			catch (URISyntaxException e)
 			{
-				log.warn(String.format("Ignore resource with invalid URI %s", response.getHref().get(0)));
+				log.warning(String.format("Ignore resource with invalid URI %s", response.getHref().get(0)));
 			}
 		}
 		return resources;
@@ -535,7 +533,7 @@ public class SardineImpl implements Sardine
 			}
 			catch (URISyntaxException e)
 			{
-				log.warn(String.format("Ignore resource with invalid URI %s", response.getHref().get(0)));
+				log.warning(String.format("Ignore resource with invalid URI %s", response.getHref().get(0)));
 			}
 		}
 		return resources;


### PR DESCRIPTION
…assles when mixing with other third party libraries. Safest is to just use JUL logging especially in a third-party library in order to avoid class path issues. Otherwise, the necessary bridging can become complicated.