### PR TITLE
Several small enhancements and bugfixes

### DIFF
--- a/src/main/java/com/github/sardine/DavResource.java
+++ b/src/main/java/com/github/sardine/DavResource.java
@@ -23,7 +23,12 @@ import org.w3c.dom.Element;
 import javax.xml.namespace.QName;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -350,7 +355,7 @@ public class DavResource
 					}
 					for (Element element : rt.getAny())
 					{
-						resourceTypes.add(new QName(element.getNamespaceURI(), element.getTagName()));
+						resourceTypes.add(new QName(element.getNamespaceURI(), element.getLocalName()));
 					}
 				}
 			}
@@ -467,7 +472,7 @@ public class DavResource
 	}
 
 	/**
-	 * @return Display name
+	 * @return Resource types
 	 */
 	public List<QName> getResourceTypes()
 	{

--- a/src/main/java/com/github/sardine/Sardine.java
+++ b/src/main/java/com/github/sardine/Sardine.java
@@ -52,7 +52,8 @@ public interface Sardine
 	 * Gets a directory listing using WebDAV <code>PROPFIND</code>.
 	 *
 	 * @param url   Path to the resource including protocol and hostname
-	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing)
+	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing,
+	 *              -1 for infinite recursion)
 	 * @return List of resources for this URI including the parent resource itself
 	 * @throws IOException I/O error or HTTP response validation failure
 	 */
@@ -62,7 +63,8 @@ public interface Sardine
 	 * Gets a directory listing using WebDAV <code>PROPFIND</code>.
 	 *
 	 * @param url   Path to the resource including protocol and hostname
-	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing)
+	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing,
+	 *              -1 for infinite recursion)
 	 * @param props Additional properties which should be requested.
 	 * @return List of resources for this URI including the parent resource itself
 	 * @throws IOException I/O error or HTTP response validation failure
@@ -73,14 +75,27 @@ public interface Sardine
 	 * Gets a directory listing using WebDAV <code>PROPFIND</code>.
 	 *
 	 * @param url   Path to the resource including protocol and hostname
-	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing)
+	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing,
+	 *              -1 for infinite recursion)
 	 * @param allProp If allprop should be used, which can be inefficient sometimes;
 	 * warning: no allprop does not retrieve custom props, just the basic ones
 	 * @return List of resources for this URI including the parent resource itself
 	 * @throws IOException I/O error or HTTP response validation failure
 	 */
-	List<DavResource> list(String url, int depth, boolean allProp)
-			throws IOException;
+	List<DavResource> list(String url, int depth, boolean allProp) throws IOException;
+
+	/**
+	 * Fetches a resource using WebDAV <code>PROPFIND</code>. Only the specified properties
+	 * are retrieved.
+	 *
+	 * @param url   Path to the resource including protocol and hostname
+	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing,
+	 *              -1 for infinite recursion)
+	 * @param props Set of properties to be requested.
+	 * @return List of resources for this URI including the parent resource itself
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	List<DavResource> propfind(String url, int depth, Set<QName> props) throws IOException;
 
 	/**
 	 * Perform a search of the Webdav repository.
@@ -226,7 +241,7 @@ public interface Sardine
 	void put(String url, InputStream dataStream, Map<String, String> headers) throws IOException;
 
 	/**
-	 * Uses <code>PUT</code> to upload file to a server with specific contentType. 
+	 * Uses <code>PUT</code> to upload file to a server with specific contentType.
 	 * Repeatable on authentication failure.
 	 *
 	 * @param url		Path to the resource including protocol and hostname
@@ -237,7 +252,7 @@ public interface Sardine
 	void put(String url, File localFile, String contentType) throws IOException;
 
 	/**
-	 * Uses <code>PUT</code> to upload file to a server with specific contentType. 
+	 * Uses <code>PUT</code> to upload file to a server with specific contentType.
 	 * Repeatable on authentication failure.
 	 *
 	 * @param url       Path to the resource including protocol and hostname

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -16,64 +16,17 @@
 
 package com.github.sardine.impl;
 
-import com.github.sardine.DavAce;
-import com.github.sardine.DavAcl;
-import com.github.sardine.DavPrincipal;
-import com.github.sardine.DavQuota;
-import com.github.sardine.DavResource;
-import com.github.sardine.Sardine;
-import com.github.sardine.Version;
+import com.github.sardine.*;
 import com.github.sardine.impl.handler.ExistsResponseHandler;
 import com.github.sardine.impl.handler.LockResponseHandler;
 import com.github.sardine.impl.handler.MultiStatusResponseHandler;
 import com.github.sardine.impl.handler.VoidResponseHandler;
 import com.github.sardine.impl.io.ConsumingInputStream;
 import com.github.sardine.impl.io.ContentLengthInputStream;
-import com.github.sardine.impl.methods.HttpAcl;
-import com.github.sardine.impl.methods.HttpCopy;
-import com.github.sardine.impl.methods.HttpLock;
-import com.github.sardine.impl.methods.HttpMkCol;
-import com.github.sardine.impl.methods.HttpMove;
-import com.github.sardine.impl.methods.HttpPropFind;
-import com.github.sardine.impl.methods.HttpPropPatch;
-import com.github.sardine.impl.methods.HttpSearch;
-import com.github.sardine.impl.methods.HttpUnlock;
-import com.github.sardine.model.Ace;
-import com.github.sardine.model.Acl;
-import com.github.sardine.model.Allprop;
-import com.github.sardine.model.Displayname;
-import com.github.sardine.model.Exclusive;
-import com.github.sardine.model.Group;
-import com.github.sardine.model.Lockinfo;
-import com.github.sardine.model.Lockscope;
-import com.github.sardine.model.Locktype;
-import com.github.sardine.model.Multistatus;
-import com.github.sardine.model.ObjectFactory;
-import com.github.sardine.model.Owner;
-import com.github.sardine.model.PrincipalCollectionSet;
-import com.github.sardine.model.PrincipalURL;
-import com.github.sardine.model.Prop;
-import com.github.sardine.model.Propertyupdate;
-import com.github.sardine.model.Propfind;
-import com.github.sardine.model.Propstat;
-import com.github.sardine.model.QuotaAvailableBytes;
-import com.github.sardine.model.QuotaUsedBytes;
-import com.github.sardine.model.Remove;
-import com.github.sardine.model.Resourcetype;
-import com.github.sardine.model.Response;
-import com.github.sardine.model.SearchRequest;
-import com.github.sardine.model.Set;
-import com.github.sardine.model.Write;
+import com.github.sardine.impl.methods.*;
+import com.github.sardine.model.*;
 import com.github.sardine.util.SardineUtil;
-
-import java.io.File;
-
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
+import org.apache.http.*;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.AuthState;
 import org.apache.http.auth.NTCredentials;
@@ -83,12 +36,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.*;
 import org.apache.http.client.params.AuthPolicy;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.protocol.RequestAcceptEncoding;
@@ -104,14 +52,11 @@ import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.FileEntity;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.*;
 import org.apache.http.impl.conn.DefaultSchemePortResolver;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
@@ -122,7 +67,7 @@ import org.apache.http.util.VersionInfo;
 import org.w3c.dom.Element;
 
 import javax.xml.namespace.QName;
-
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ProxySelector;
@@ -134,8 +79,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Logger;
-
-import org.apache.http.entity.FileEntity;
 
 /**
  * Implementation of the Sardine interface. This is where the meat of the Sardine library lives.
@@ -170,6 +113,16 @@ public class SardineImpl implements Sardine
 	public SardineImpl()
 	{
 		this.builder = this.configure(null, null);
+		this.client = this.builder.build();
+	}
+
+	/**
+	 * Access resources with Bearer authorization
+	 */
+	public SardineImpl(String bearerAuth)
+	{
+		Header bearerHeader = new BasicHeader("Authorization", "Bearer " + bearerAuth);
+		this.builder = this.configure(null, null).setDefaultHeaders(Collections.singletonList(bearerHeader));
 		this.client = this.builder.build();
 	}
 

--- a/src/main/java/com/github/sardine/impl/SardineRedirectStrategy.java
+++ b/src/main/java/com/github/sardine/impl/SardineRedirectStrategy.java
@@ -16,6 +16,8 @@
 
 package com.github.sardine.impl;
 
+import com.github.sardine.impl.methods.HttpPropFind;
+import org.apache.http.Header;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -25,16 +27,12 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.protocol.HttpContext;
 
-import com.github.sardine.impl.methods.HttpPropFind;
-
-/**
- * @version $Id:$
- */
 public class SardineRedirectStrategy extends DefaultRedirectStrategy {
 
     @Override
     protected boolean isRedirectable(String method) {
-        if(super.isRedirectable(method)) {
+        if (super.isRedirectable(method))
+        {
             return true;
         }
         return method.equalsIgnoreCase(HttpPropFind.METHOD_NAME);
@@ -42,17 +40,25 @@ public class SardineRedirectStrategy extends DefaultRedirectStrategy {
 
     @Override
     public HttpUriRequest getRedirect(HttpRequest request, HttpResponse response, HttpContext context)
-            throws ProtocolException {
+            throws ProtocolException
+    {
         String method = request.getRequestLine().getMethod();
-        if(method.equalsIgnoreCase(HttpPropFind.METHOD_NAME)) {
-            return this.copyEntity(new HttpPropFind(this.getLocationURI(request, response, context)), request);
+        if (method.equalsIgnoreCase(HttpPropFind.METHOD_NAME))
+        {
+            HttpPropFind propfind = new HttpPropFind(this.getLocationURI(request, response, context));
+            Header depth = request.getFirstHeader("Depth");
+            if (depth != null && depth.getValue() != null)
+            {
+                propfind.setDepth(depth.getValue());
+            }
+            return this.copyEntity(propfind, request);
         }
         return super.getRedirect(request, response, context);
     }
 
-    private HttpUriRequest copyEntity(
-            final HttpEntityEnclosingRequestBase redirect, final HttpRequest original) {
-        if(original instanceof HttpEntityEnclosingRequest) {
+    private HttpUriRequest copyEntity(final HttpEntityEnclosingRequestBase redirect, final HttpRequest original) {
+        if (original instanceof HttpEntityEnclosingRequest)
+        {
             redirect.setEntity(((HttpEntityEnclosingRequest) original).getEntity());
         }
         return redirect;

--- a/src/main/java/com/github/sardine/impl/methods/HttpPropFind.java
+++ b/src/main/java/com/github/sardine/impl/methods/HttpPropFind.java
@@ -16,10 +16,10 @@
 
 package com.github.sardine.impl.methods;
 
-import java.net.URI;
-
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
 
 /**
  * Simple class for making WebDAV <code>PROPFIND</code> requests.
@@ -42,7 +42,7 @@ public class HttpPropFind extends HttpEntityEnclosingRequestBase
 	 */
 	public HttpPropFind(final URI uri)
 	{
-		this.setDepth(String.valueOf("1"));
+		this.setDepth("1");
 		this.setURI(uri);
 		this.setHeader(HttpHeaders.CONTENT_TYPE, "text/xml; charset=utf-8");
 	}
@@ -59,8 +59,9 @@ public class HttpPropFind extends HttpEntityEnclosingRequestBase
 	 *
 	 * @param depth <code>"0"</code>, <code>"1"</code> or <code>"infinity"</code>.
 	 */
-	public void setDepth(String depth)
+	public HttpPropFind setDepth(String depth)
 	{
 		this.setHeader(HttpHeaders.DEPTH, depth);
+		return this;
 	}
 }

--- a/src/test/java/com/github/sardine/DavResourceTest.java
+++ b/src/test/java/com/github/sardine/DavResourceTest.java
@@ -19,8 +19,10 @@ package com.github.sardine;
 import org.junit.Test;
 
 import javax.xml.namespace.QName;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -33,7 +35,7 @@ public class DavResourceTest
 	{
 		final Date creation = new Date();
 		DavResource folder = new DavResource("/test/path/", creation, null, null, -1L, null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals(creation, folder.getCreation());
 	}
 
@@ -42,7 +44,7 @@ public class DavResourceTest
 	{
 		final Date modified = new Date();
 		DavResource folder = new DavResource("/test/path/", null, modified, null, -1L, null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals(modified, folder.getModified());
 	}
 
@@ -50,7 +52,7 @@ public class DavResourceTest
 	public void testGetContentType() throws Exception
 	{
 		DavResource folder = new DavResource("/test/path/", null, null, "httpd/unix-directory", new Long(-1), null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals("httpd/unix-directory", folder.getContentType());
 	}
 
@@ -58,7 +60,7 @@ public class DavResourceTest
 	public void testGetContentLength() throws Exception
 	{
 		DavResource folder = new DavResource("/test/path/", null, null, null, 3423L, null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals(new Long(3423), folder.getContentLength());
 	}
 
@@ -66,7 +68,7 @@ public class DavResourceTest
 	public void testGetContentLanguage() throws Exception
 	{
 		DavResource folder = new DavResource("/test/path/", null, null, null, -1L, null,
-				null, "en_us", Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), "en_us", Collections.<QName, String>emptyMap());
 		assertEquals("en_us", folder.getContentLanguage());
 	}
 
@@ -74,15 +76,24 @@ public class DavResourceTest
 	public void testDisplayname() throws Exception
 	{
 		DavResource folder = new DavResource("/test/path/", null, null, null, -1L, null,
-				"My path", null, Collections.<QName, String>emptyMap());
+				"My path", Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals("My path", folder.getDisplayName());
+	}
+
+	@Test
+	public void testResourcetype() throws Exception
+	{
+		List<QName> types = Arrays.asList(new QName("namespace", "tag"), new QName("namespace", "othertag"));
+		DavResource folder = new DavResource("/test/path/", null, null, null, -1L, null,
+				null, types, null, Collections.<QName, String>emptyMap());
+		assertEquals(types, folder.getResourceTypes());
 	}
 
 	@Test
 	public void testIsDirectory() throws Exception
 	{
 		DavResource folder = new DavResource("/test/path/", null, null, "httpd/unix-directory", new Long(-1), null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertTrue(folder.isDirectory());
 	}
 
@@ -91,12 +102,12 @@ public class DavResourceTest
 	{
         {
             DavResource file = new DavResource("/test/path/file.html", null, null, null, 6587L, null,
-                    null, null, Collections.<QName, String>emptyMap());
+                    null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
             assertNotNull(file.getCustomProps());
         }
         {
             DavResource file = new DavResource("/test/path/file.html", null, null, null, 6587L, null,
-          				null, null, Collections.<QName, String>singletonMap(
+          				null, Collections.<QName>emptyList(), null, Collections.<QName, String>singletonMap(
                                   new QName("http://mynamespace", "property", "my"), "custom"));
             assertNotNull(file.getCustomProps());
             assertEquals(file.getCustomProps(), Collections.singletonMap("property", "custom"));
@@ -109,10 +120,10 @@ public class DavResourceTest
 	public void testGetName() throws Exception
 	{
 		DavResource folder = new DavResource("/test/path/", null, null, null, -1L, null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals("path", folder.getName());
 		DavResource file = new DavResource("/test/path/file.html", null, null, null, 6587L, null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals("file.html", file.getName());
 	}
 
@@ -120,10 +131,10 @@ public class DavResourceTest
 	public void testGetPath() throws Exception
 	{
 		DavResource folder = new DavResource("/test/path/", null, null, null, -1L, null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals("/test/path/", folder.getPath());
 		DavResource file = new DavResource("/test/path/file.html", null, null, null, 6587L, null,
-				null, null, Collections.<QName, String>emptyMap());
+				null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 		assertEquals("/test/path/file.html", file.getPath());
 	}
 
@@ -132,13 +143,13 @@ public class DavResourceTest
 	{
 		{
 			DavResource folder = new DavResource("/test/path/", null, null, "httpd/unix-directory", 3423L, null,
-					null, null, Collections.<QName, String>emptyMap());
+					null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 			assertEquals("/test/path/", folder.getPath());
 		}
 		{
 			DavResource folder = new DavResource("http://example.net/test/path/", null, null,
 					"httpd/unix-directory", 3423L, null,
-					null, null, Collections.<QName, String>emptyMap());
+					null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 			assertEquals("/test/path/", folder.getPath());
 		}
 	}
@@ -149,13 +160,13 @@ public class DavResourceTest
 		{
 			DavResource resource = new DavResource("http://example.net/path/%C3%A4%C3%B6%C3%BC/", null, null,
 					"httpd/unix-directory", 3423L, null,
-					null, null, Collections.<QName, String>emptyMap());
+					null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 			assertEquals("/path/äöü/", resource.getPath());
 			assertEquals("/path/%C3%A4%C3%B6%C3%BC/", resource.getHref().getRawPath());
 		}
 		{
 			DavResource resource = new DavResource("/Meine%20Anlagen", null, null, "httpd/unix-directory", 0L, null,
-					null, null, Collections.<QName, String>emptyMap());
+					null, Collections.<QName>emptyList(), null, Collections.<QName, String>emptyMap());
 			assertEquals("/Meine Anlagen", resource.getPath());
 			assertEquals("/Meine%20Anlagen", resource.getHref().getRawPath());
 		}


### PR DESCRIPTION
* On redirect, PROPFIND depth was always being reset to "1". This change maintains the Depth header through HTTP redirect.
* Adds support for Bearer authorization with a new `SardineImpl` constructor
* Exposes *resourcetype* attribute on `DavResource`
* Supports Depth: infinite on PROPFIND via negative values of depth parameter
* Adds a new `Sardine.propfind` method that acts as a `list` without fetching default props