### PR TITLE
Fixed Quota Request Bug (NullPointerException) when the resource is N…

### DIFF
--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -680,7 +680,8 @@ public class SardineImpl implements Sardine
 		}
 		else
 		{
-                    if (responses.get(0).getPropstat().get(0).getStatus().contains("200")) return new DavQuota(responses.get(0));
+                    DavResource resource = new DavResource(responses.get(0));
+                    if (resource.getStatusCode() == 200) return new DavQuota(resource);
 		}
                 return null;
 	}

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -680,8 +680,9 @@ public class SardineImpl implements Sardine
 		}
 		else
 		{
-			return new DavQuota(responses.get(0));
+                    if (responses.get(0).getPropstat().get(0).getStatus().contains("200")) return new DavQuota(responses.get(0));
 		}
+                return null;
 	}
 
 	@Override


### PR DESCRIPTION
Fixed Quota Request Bug (NullPointerException) when the resource is Not Found. Now, it checks if the resource is OK (200) before creating the DavQuota object

Because the Webdav Quota property is optional. I was having a problem (NullPointerException) with a 404 response from a server when I required the properties. Now I changed the code to check if the response if 200 (OK) before creating the DavQuota object.

Maybe the way I fixed this issue is not the best, but it works ;)
