### PR TITLE
make httpClient protected. Try to introduce single entry point for internal execute implementation

### DIFF
--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -1019,11 +1019,11 @@ public class SardineImpl implements Sardine
 	 * Common method as single entry point responsible fo request execution
 	 * @param context clientContext to be used when executing request
 	 * @param request Request to execute
-	 * @param maybeResponseHandler can be null if you need raw HttpResponse or not null response handler for result handling.
-	 * @param <T> will return raw HttpResponse when maybeResponseHandler is null or value reslved using provided ResponseHandler instance
-	 * @return value resolved using response handler or raw HttpResponse when maybeResponseHandler is null
+	 * @param responseHandler can be null if you need raw HttpResponse or not null response handler for result handling.
+	 * @param <T> will return raw HttpResponse when responseHandler is null or value reslved using provided ResponseHandler instance
+	 * @return value resolved using response handler or raw HttpResponse when responseHandler is null
 	 */
-	protected <T> T execute(HttpClientContext context, HttpRequestBase request, ResponseHandler<T> maybeResponseHandler)
+	protected <T> T execute(HttpClientContext context, HttpRequestBase request, ResponseHandler<T> responseHandler)
 			throws IOException
 	{
 		try
@@ -1031,9 +1031,9 @@ public class SardineImpl implements Sardine
 			// Clear circular redirect cache
 			context.removeAttribute(HttpClientContext.REDIRECT_LOCATIONS);
 
-			if (maybeResponseHandler != null)
+			if (responseHandler != null)
 			{
-				return this.client.execute(request, maybeResponseHandler, context);
+				return this.client.execute(request, responseHandler, context);
 			}
 			else
 			{

--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -149,7 +149,7 @@ public class SardineImpl implements Sardine
 	/**
 	 * HTTP client implementation
 	 */
-	private CloseableHttpClient client;
+	protected CloseableHttpClient client;
 
 	/**
 	 * HTTP client configuration


### PR DESCRIPTION
Two changes.
First is protected httpClient so other users should be able to introduce they own logic around execute methods.

Second one is ugly hack :( I've been trying to introduce single point of entry for all execute methods. It works but it's ugly and I have no idea how to make it look better and less hacky but it does its job...