### PR TITLE
Close Unmarshaller after using it

### DIFF
--- a/src/main/java/com/github/sardine/util/SardineUtil.java
+++ b/src/main/java/com/github/sardine/util/SardineUtil.java
@@ -20,6 +20,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.sax.SAXSource;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -195,6 +196,20 @@ public final class SardineUtil
 			// Backward compatibility
 			failure.initCause(e);
 			throw failure;
+		}
+		finally
+		{
+			if (unmarshaller instanceof Closeable)
+			{
+				try
+				{
+					((Closeable) unmarshaller).close();
+				}
+				catch (IOException e)
+				{
+					// there's not much we can do here
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Prevent memory leak by checking if the Unmarshaller is Closeable and closing it if it is (see also https://java.net/jira/browse/JAXB-1000).