### PR TITLE
Remove misleading JavaDoc for DavResource.getName if the resource is a directory

### DIFF
--- a/src/main/java/com/github/sardine/DavResource.java
+++ b/src/main/java/com/github/sardine/DavResource.java
@@ -547,7 +547,7 @@ public class DavResource
 	/**
 	 * Last path component.
 	 *
-	 * @return The name of the resource URI decoded. An empty string if this resource denotes a directory.
+	 * @return The name of the resource URI decoded.
 	 * @see #getHref()
 	 */
 	public String getName()


### PR DESCRIPTION
Closes #260