### PR TITLE
FIX: Ensure HttpEnity InputStream is closed in any case

### DIFF
--- a/src/main/java/com/github/sardine/impl/io/HttpMethodReleaseInputStream.java
+++ b/src/main/java/com/github/sardine/impl/io/HttpMethodReleaseInputStream.java
@@ -70,6 +70,8 @@ public class HttpMethodReleaseInputStream extends ByteCountInputStream
 				// connections unavailable for reuse.
 				// The response proxy will force close the connection.
 				((CloseableHttpResponse) response).close();
+				// Close the entity stream
+				super.close();
 			}
 		}
 		else


### PR DESCRIPTION
We noticed some blocking in our NextCloud-based application despite connect & read timeouts properly set. Digging through the Sardine code we found a possible resource leak that is especially important as it is triggered when working with transfer-compressed (f.e. GZIP) connections. Unclosed compression-handling input-/outputstreams is the most common case for native memory leaks in Java, I suppose.

With the provided patch it is ensured that the underlying HttpEntity InputStream is closed in any case.