### PR TITLE
Hotfix: Explicitly pass class loader to avoid class loading issues

### DIFF
--- a/src/main/java/com/github/sardine/util/SardineUtil.java
+++ b/src/main/java/com/github/sardine/util/SardineUtil.java
@@ -85,8 +85,7 @@ public final class SardineUtil
 	{
 		try
 		{
-			Class<ObjectFactory> objectFactoryClass = ObjectFactory.class;
-			JAXB_CONTEXT = JAXBContext.newInstance(objectFactoryClass.getPackage().getName(), objectFactoryClass.getClassLoader());
+			JAXB_CONTEXT = JAXBContext.newInstance(ObjectFactory.class.getPackage().getName(), SardineUtil.class.getClassLoader());
 		}
 		catch (JAXBException e)
 		{

--- a/src/main/java/com/github/sardine/util/SardineUtil.java
+++ b/src/main/java/com/github/sardine/util/SardineUtil.java
@@ -85,7 +85,8 @@ public final class SardineUtil
 	{
 		try
 		{
-			JAXB_CONTEXT = JAXBContext.newInstance(ObjectFactory.class);
+			Class<ObjectFactory> objectFactoryClass = ObjectFactory.class;
+			JAXB_CONTEXT = JAXBContext.newInstance(objectFactoryClass.getPackage().getName(), objectFactoryClass.getClassLoader());
 		}
 		catch (JAXBException e)
 		{


### PR DESCRIPTION
Explicitly passing the class loader of the current class avoids class loading issues when JAXB is used in application servers, J2EE containers and other applications that use sophisticated class loading mechanisms (see https://javaee.github.io/jaxb-v2/doc/user-guide/ch06.html#d0e6919).

As the JAXB FAQ states:

> In general, if you are writing code that uses JAXB, it is always better to explicitly pass in a class loader, so that your code will work no matter where it is deployed.