### PR TITLE
updated to http-client 4.5.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.9</version>
         </dependency>
         <!-- ant and junit must be defined as provided for a successful compile. -->
         <dependency>

--- a/src/test/java/com/github/sardine/impl/io/ByteCountInputStreamTest.java
+++ b/src/test/java/com/github/sardine/impl/io/ByteCountInputStreamTest.java
@@ -16,6 +16,7 @@ public class ByteCountInputStreamTest
 		in.read();
 		assertEquals(1, in.getByteCount(), 0L);
 		in.read(new byte[2]);
+        in.close();
 	}
 
 	@Test
@@ -24,6 +25,7 @@ public class ByteCountInputStreamTest
 		final ByteCountInputStream in = new ByteCountInputStream(new ByteArrayInputStream(new byte[2]));
 		in.read(new byte[2]);
 		assertEquals(2, in.getByteCount(), 0L);
+        in.close();
 	}
 
 	@Test
@@ -32,5 +34,6 @@ public class ByteCountInputStreamTest
 		final ByteCountInputStream in = new ByteCountInputStream(new ByteArrayInputStream(new byte[2]));
 		in.read(new byte[2], 1, 1);
 		assertEquals(1, in.getByteCount(), 0L);
+        in.close();
 	}
 }


### PR DESCRIPTION
Updated to a newer http-client lib 4.5.9 instead of 4.5.1 (uses internally also a newer commons-codec version, that we need)