### PR TITLE
Ant RecursiveGet: fixed exception, added skipExistingFiles option

### DIFF
--- a/src/main/java/com/github/sardine/ant/command/RecursiveGet.java
+++ b/src/main/java/com/github/sardine/ant/command/RecursiveGet.java
@@ -37,6 +37,11 @@ public class RecursiveGet extends Command {
 	boolean overwriteFiles = false;
 
 	/**
+	 * true if existent local files will be skipped; otherwise, false.
+	 */
+	boolean skipExistingFiles = false;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	@Override
@@ -78,6 +83,11 @@ public class RecursiveGet extends Command {
 				String filePathRelativeToRemoteDirectory = davResource.getPath().replace(remoteDirectoryPath, "");
 				Path localFilePath = Paths.get(localDirectory, filePathRelativeToRemoteDirectory);
 
+				if (skipExistingFiles && Files.exists(localFilePath)) {
+					log("skipping download of already existing file " + localFilePath);
+					continue;
+				}
+
 				Files.createDirectories(localFilePath.getParent());
 
 				log("downloading " + filePathRelativeToRemoteDirectory + " to " + localFilePath);
@@ -114,4 +124,7 @@ public class RecursiveGet extends Command {
 		this.overwriteFiles = overwriteFiles;
 	}
 
+	public void setSkipExistingFiles(boolean skipExistingFiles) {
+		this.skipExistingFiles = skipExistingFiles;
+	}
 }

--- a/src/main/java/com/github/sardine/ant/command/RecursiveGet.java
+++ b/src/main/java/com/github/sardine/ant/command/RecursiveGet.java
@@ -13,7 +13,7 @@ import com.github.sardine.ant.Command;
 
 /**
  * A nice ant wrapper around sardine.list() and sardine.get().
- * 
+ *
  * @author andreafonti
  */
 public class RecursiveGet extends Command {
@@ -82,8 +82,7 @@ public class RecursiveGet extends Command {
 
 				log("downloading " + filePathRelativeToRemoteDirectory + " to " + localFilePath);
 
-				String remoteFileUrl = new URI(serverUrl + '/').resolve(davResource.getPath()).toString();
-				InputStream ioStream = getSardine().get(remoteFileUrl);
+				InputStream ioStream = getSardine().get(serverUrl + davResource.getHref().toString());
 				try {
 					if (overwriteFiles) {
 						Files.copy(ioStream, localFilePath, StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
Had an IllegalArgumentException when using the recursive get ant task on a remote dir with spaces in the pathname
Also added an option to skip already existing files to the ant task

It would be nice to get a release of this :)

