### PR TITLE
Fix preemptive authentication without explicit port (#285)

### DIFF
--- a/src/main/java/com/github/sardine/impl/SardineImpl.java
+++ b/src/main/java/com/github/sardine/impl/SardineImpl.java
@@ -371,8 +371,8 @@ public class SardineImpl implements Sardine
 		// Generate Basic preemptive scheme object and stick it to the local execution context
 		BasicScheme basicAuth = new BasicScheme(credentialsCharset);
 		// Configure HttpClient to authenticate preemptively by prepopulating the authentication data cache.
-		cache.put(new HttpHost(hostname, httpPort, "http"), basicAuth);
-		cache.put(new HttpHost(hostname, httpsPort, "https"), basicAuth);
+		cache.put(new HttpHost(hostname, httpPort == -1 ? 80 : httpPort, "http"), basicAuth);
+		cache.put(new HttpHost(hostname, httpsPort == -1 ? 443 : httpsPort, "https"), basicAuth);
 	}
 
 	@Override


### PR DESCRIPTION
In SardineImpl.enablePreemptiveAuthentication(String, int, int,
Charset), do not pass -1 to the HttpHost constructor. The later cache
lookup is always done with an explicit port, so port -1 never matches
and the entry does nothing. Instead, we need to use the default port
explicitly, then it will work, even when connecting with a URL that does
not include the port.

Since the other overloads delegate to this one, this fixes all overloads
to do the right thing, in particular, the
enablePreemptiveAuthentication(String) (hostname-only) and
enablePreemptiveAuthentication(URL) (when using a URL without an
explicit port) ones.

Fixes #285.