### PR TITLE
Add Automatic-Module-Name to manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,9 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
+                        <manifestEntries>
+                          <Automatic-Module-Name>com.github.sardine</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Add Automatic-Module-Name to manifest, see http://branchandbound.net/blog/java/2017/12/automatic-module-name/ Without an explicit name, the compiler will warn when attempting to use this library

```
[INFO] --- compiler:3.11.0:compile (default-compile) @ simple-servlet-container-tests-common ---
[WARNING] ****************************************************************************************************************************************
[WARNING] * Required filename-based automodules detected: [sardine-5.10.jar]. Please don't publish this project to a public artifact repository! *
[WARNING] ****************************************************************************************************************************************
```