### PR TITLE
Return status from first propstat element when found.

### DIFF
--- a/src/main/java/com/github/sardine/DavResource.java
+++ b/src/main/java/com/github/sardine/DavResource.java
@@ -168,6 +168,18 @@ public class DavResource
 	 */
 	private int getStatusCode(Response response)
 	{
+		List<Propstat> list = response.getPropstat();
+		for(Propstat propstat : list) {
+			if(propstat.getStatus() != null) {
+				try {
+					return BasicLineParser.parseStatusLine(propstat.getStatus(), null).getStatusCode();
+				}
+				catch(ParseException e) {
+					log.warning(String.format("Failed to parse status line: %s", propstat.getStatus()));
+					return -1;
+				}
+			}
+		}
 		String status = response.getStatus();
 		if (status == null || status.isEmpty())
 		{

--- a/src/test/java/com/github/sardine/FunctionalSardineTest.java
+++ b/src/test/java/com/github/sardine/FunctionalSardineTest.java
@@ -226,8 +226,7 @@ public class FunctionalSardineTest
         Sardine sardine = SardineFactory.begin();
         sardine.createDirectory(url);
         DavQuota davQuota = sardine.getQuota(url);
-        assertTrue(davQuota.getQuotaAvailableBytes() > 0);
-        assertEquals(0, davQuota.getQuotaUsedBytes());
+        assertNull(davQuota);
     }
 
     @Test(expected = SardineException.class)


### PR DESCRIPTION
Properly map the status code in a `PROPFIND`  response element like

```
  <d:response>
    <d:href>/remote.php/dav/files/test/temp1gb.bin</d:href>
    <d:propstat>
      <d:prop>
        <d:getcontentlength>1073741824</d:getcontentlength>
        <d:getcontenttype>application/octet-stream</d:getcontenttype>
        <d:getetag>"57939359671f9a2ff67213b437d26bb8"</d:getetag>
        <d:getlastmodified>Thu, 09 Jan 2025 10:10:54 GMT</d:getlastmodified>
        <d:resourcetype/>
        <oc:fileid>83a8ea67-9b48-41a1-97c0-729e8b47ddba$868b2de7-a01d-42c3-8df1-184669d5dc29!07dc62ba-6df5-4c85-880f-d905f6f6a8cb</oc:fileid>
        <oc:size>1073741824</oc:size>
        <oc:checksums>
          <oc:checksum>SHA1:2a492f15396a6768bcbca016993f4b4c8b0b5307 MD5:cd573cfaace07e7949bc0c46028904ff ADLER32:c02d0001</oc:checksum>
        </oc:checksums>
      </d:prop>
      <d:status>HTTP/1.1 425 TOO EARLY</d:status>
    </d:propstat>
  </d:response>
```